### PR TITLE
Add cloud websocket push for real-time device updates and events

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ Custom component to allow control of [Leviton Decora Smart Wi-Fi devices](https:
 - Additional entities have been added to manage configuration for each device as well (ex. auto shutoff, max/min dimming levels, etc.).
 - Support for activities (`button`), Home/Away status (`select`), scenes (`scene`), and schedules (`switch`) is also included.
 - Support for two-factor authentication.
-- **Real-time cloud push via the MyLeviton websocket** — state changes and physical button presses on scene controllers (DW4BC, D2SCS) arrive in ~2 seconds instead of waiting for the polling interval.
+- **Real-time cloud push via the MyLeviton websocket**
+    - State changes on all devices in general are reflected instantly
+    - Physical button presses on scene controllers (DW4BC, D2SCS) are reflected in a few seconds (due to limitations from Leviton's API).
+    - Changes for residence, schedules, or activities still rely on polling
 
 ## Button presses
 Each controller button is exposed as an `event` entity (e.g. `event.<controller>_<button_name>_press`). Use it as a state trigger in automations:
@@ -20,7 +23,7 @@ triggers:
     not_to:   [unavailable, unknown]
 ```
 
-Note: Leviton's cloud only emits `btnPress` notifications for buttons that have at least one action configured in the **MyLeviton mobile app**. Bind each button you want to expose in HA to *any* placeholder action in the Leviton app — the button itself doesn't need to do anything meaningful for HA to receive the press.
+*Note: Leviton's API only emits `btnPress` notifications for buttons that have at least one action configured in the MyLeviton mobile app. Bind each button you want to expose in Home Assistant to any placeholder action in the MyLeviton app, the button itself doesn't need to do anything meaningful for Home Assistant to receive the press.*
 
 ## Install
 1. Ensure Home Assistant is updated to version 2026.3.0 or newer.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,20 @@ Custom component to allow control of [Leviton Decora Smart Wi-Fi devices](https:
 - Additional entities have been added to manage configuration for each device as well (ex. auto shutoff, max/min dimming levels, etc.).
 - Support for activities (`button`), Home/Away status (`select`), scenes (`scene`), and schedules (`switch`) is also included.
 - Support for two-factor authentication.
+- **Real-time cloud push via the MyLeviton websocket** — state changes and physical button presses on scene controllers (DW4BC, D2SCS) arrive in ~2 seconds instead of waiting for the polling interval.
+
+## Button presses
+Each controller button is exposed as an `event` entity (e.g. `event.<controller>_<button_name>_press`). Use it as a state trigger in automations:
+
+```yaml
+triggers:
+  - trigger: state
+    entity_id: event.your_controller_button_1_press
+    not_from: [unavailable, unknown]
+    not_to:   [unavailable, unknown]
+```
+
+Note: Leviton's cloud only emits `btnPress` notifications for buttons that have at least one action configured in the **MyLeviton mobile app**. Bind each button you want to expose in HA to *any* placeholder action in the Leviton app — the button itself doesn't need to do anything meaningful for HA to receive the press.
 
 ## Install
 1. Ensure Home Assistant is updated to version 2026.3.0 or newer.
@@ -52,6 +66,5 @@ Custom component to allow control of [Leviton Decora Smart Wi-Fi devices](https:
 - DW15S
 
 ## Future Plans
-- Websocket support to allow for cloud push updates (any help with this would be appreciated as I have no experience with websockets).
 - Control of night settings start/end time
 - Support for D2GF2, DN15S, DN6HD, MLWSB

--- a/custom_components/leviton_decora_smart_wifi/__init__.py
+++ b/custom_components/leviton_decora_smart_wifi/__init__.py
@@ -8,14 +8,18 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    CONF_EMAIL,
     CONF_ID,
     CONF_NAME,
+    CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
     CONF_TOKEN,
     Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -32,19 +36,24 @@ from .api.residence import Residence as LevitonResidence
 from .api.room import Room as LevitonRoom
 from .api.scene import Scene as LevitonScene
 from .api.schedule import Schedule as LevitonSchedule
+from .api.websocket import LevitonWebSocket
 from .const import (
     CONF_DEVICES,
+    CONF_LOGIN_RESPONSE,
     CONF_RESIDENCES,
     CONF_SAVE_RESPONSES,
     CONF_TIMEOUT,
     CONFIGURATION_URL,
     DATA_API,
     DATA_COORDINATOR,
+    DATA_WEBSOCKET,
     DEFAULT_SAVE_LOCATION,
     DEFAULT_SAVE_RESPONSES,
     DEVICE_INFO_MANUFACTURER,
     DEVICE_INFO_MODEL_RESIDENCE,
     DOMAIN,
+    EVENT_NOTIFICATION,
+    SIGNAL_NOTIFICATION,
     UNDO_UPDATE_LISTENER,
     ScanInterval,
     Timeout,
@@ -53,6 +62,7 @@ from .const import (
 PLATFORMS = (
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.EVENT,
     Platform.FAN,
     Platform.IMAGE,
     Platform.LIGHT,
@@ -153,9 +163,107 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         UNDO_UPDATE_LISTENER: config_entry.add_update_listener(async_update_listener),
     }
 
+    websocket = await _async_start_websocket(
+        hass,
+        config_entry,
+        api,
+        coordinator,
+        conf_residences,
+        conf_devices,
+    )
+    if websocket is not None:
+        hass.data[DOMAIN][config_entry.entry_id][DATA_WEBSOCKET] = websocket
+
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
+
+
+async def _async_start_websocket(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    api: LevitonAPI,
+    coordinator: DataUpdateCoordinator,
+    conf_residences: list[int],
+    conf_devices: list[int],
+) -> LevitonWebSocket | None:
+    """Open the MyLeviton websocket using the bearer already in config.
+
+    We deliberately do NOT call ``LevitonAPI.login`` from this path:
+    each re-login attempt counts toward Leviton's "too many failed
+    attempts" lockout, and a flapping websocket will burn through them.
+    Instead we synthesize the token payload from the bearer + user id
+    already persisted in the config entry. If that auth fails the WS
+    client backs off ``AUTH_FAILURE_COOLDOWN`` (1h) before any retry.
+    """
+    bearer = config_entry.data.get(CONF_TOKEN)
+    user_id = config_entry.data.get(CONF_ID)
+    if not bearer or not user_id:
+        _LOGGER.warning("Leviton websocket disabled: bearer/user id missing")
+        return None
+
+    @callback
+    def token_provider() -> dict | None:
+        # Re-read from config_entry on every reconnect so a re-auth via
+        # the options flow propagates without an HA restart. Prefer the
+        # full login response object captured at config-flow time — the
+        # cloud's WS auth historically needs the entire response, not
+        # just the bearer + user id.
+        full = config_entry.data.get(CONF_LOGIN_RESPONSE)
+        if isinstance(full, dict) and full.get("id"):
+            return full
+        current = config_entry.data.get(CONF_TOKEN)
+        uid = config_entry.data.get(CONF_ID)
+        if not current or not uid:
+            return None
+        return {"id": current, "userId": uid}
+
+    @callback
+    def on_notification(notification: dict) -> None:
+        if not isinstance(notification, dict):
+            return
+        hass.bus.async_fire(EVENT_NOTIFICATION, notification)
+        async_dispatcher_send(
+            hass, f"{SIGNAL_NOTIFICATION}_{config_entry.entry_id}", notification
+        )
+
+    subs = _collect_subscriptions(coordinator, conf_residences, conf_devices)
+    _LOGGER.debug(
+        "Leviton websocket: starting client with %d subscription(s)", len(subs)
+    )
+    websocket = LevitonWebSocket(
+        session=async_get_clientsession(hass),
+        token_provider=token_provider,
+        on_notification=on_notification,
+    )
+    websocket.set_subscriptions(subs)
+    websocket.start()
+    return websocket
+
+
+def _collect_subscriptions(
+    coordinator: DataUpdateCoordinator,
+    conf_residences: list[int],
+    conf_devices: list[int],
+) -> list[tuple[str, int]]:
+    """Build the list of (modelName, modelId) the WS should subscribe to.
+
+    Empirically the cloud delivers physical button presses on the parent
+    IotSwitch as ``data.btnPress: [{button: N, trigger: T}]`` — there is
+    no separate IotButton push channel, so we don't subscribe to one.
+    """
+    subs: list[tuple[str, int]] = []
+    data: LevitonData | None = coordinator.data
+    if data is None:
+        return subs
+    for residence in data.residences:
+        if residence.id not in conf_residences:
+            continue
+        for device in residence.devices:
+            if device.id not in conf_devices:
+                continue
+            subs.append(("IotSwitch", device.id))
+    return subs
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -165,7 +273,11 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         platforms=PLATFORMS,
     )
     if unload_ok:
-        hass.data[DOMAIN][config_entry.entry_id][UNDO_UPDATE_LISTENER]()
+        entry_data = hass.data[DOMAIN][config_entry.entry_id]
+        entry_data[UNDO_UPDATE_LISTENER]()
+        websocket: LevitonWebSocket | None = entry_data.get(DATA_WEBSOCKET)
+        if websocket is not None:
+            await websocket.stop()
         hass.data[DOMAIN].pop(config_entry.entry_id)
 
     return unload_ok

--- a/custom_components/leviton_decora_smart_wifi/__init__.py
+++ b/custom_components/leviton_decora_smart_wifi/__init__.py
@@ -1,17 +1,13 @@
 """The Leviton Decora Smart Wi-Fi integration."""
 
-from __future__ import annotations
-
 from asyncio import timeout
 from datetime import timedelta
 import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONF_EMAIL,
     CONF_ID,
     CONF_NAME,
-    CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
     CONF_TOKEN,
     Platform,
@@ -20,23 +16,11 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.entity import EntityDescription
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import LevitonAPI, LevitonData, LevitonException
-from .api.activity import Activity as LevitonActivity
-from .api.button import Button as LevitonButton
-from .api.device import Device as LevitonDevice
-from .api.firmware import Firmware as LevitonFirmware
-from .api.residence import Residence as LevitonResidence
-from .api.room import Room as LevitonRoom
-from .api.scene import Scene as LevitonScene
-from .api.schedule import Schedule as LevitonSchedule
 from .api.websocket import LevitonWebSocket
+from .config_flow import LevitonConfigFlow
 from .const import (
     CONF_DEVICES,
     CONF_LOGIN_RESPONSE,
@@ -53,8 +37,8 @@ from .const import (
     DEVICE_INFO_MODEL_RESIDENCE,
     DOMAIN,
     EVENT_NOTIFICATION,
-    SIGNAL_NOTIFICATION,
     UNDO_UPDATE_LISTENER,
+    UPDATE_NOTIFICATION,
     ScanInterval,
     Timeout,
 )
@@ -75,6 +59,49 @@ PLATFORMS = (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class LevitonDataUpdateCoordinator(DataUpdateCoordinator[LevitonData]):
+    """Class to manage fetching data from single endpoint."""
+
+    async def _async_update_data(self) -> LevitonData:
+        """Fetch the latest data from the source."""
+        if self.update_method is None:
+            raise NotImplementedError("Update method not implemented")
+        return await self.update_method()
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    if config_entry.version > LevitonConfigFlow.VERSION:
+        return False
+
+    if config_entry.version < LevitonConfigFlow.VERSION:
+        _LOGGER.info("Migrating configuration from version: %s", config_entry.version)
+
+        data = dict(config_entry.data)
+        options = dict(config_entry.options)
+        _LOGGER.debug("Initial data:\n%s", data)
+        _LOGGER.debug("Initial options:\n%s", options)
+
+        if config_entry.version <= 1:
+            data[CONF_SCAN_INTERVAL] = ScanInterval.DEFAULT
+            options[CONF_SCAN_INTERVAL] = ScanInterval.DEFAULT
+
+        _LOGGER.debug("Migrated data:\n%s", data)
+        _LOGGER.debug("Migrated options:\n%s", options)
+
+        hass.config_entries.async_update_entry(
+            entry=config_entry,
+            data=data,
+            options=options,
+            version=LevitonConfigFlow.VERSION,
+        )
+        _LOGGER.info(
+            "Successfully migrated configuration to version: %s", config_entry.version
+        )
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -132,12 +159,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                 f"Error communicating with API, Status: {exception.status_code}, Error Name: {exception.name}, Error Message: {exception.message}"
             ) from exception
 
-    coordinator = DataUpdateCoordinator(
+    coordinator = LevitonDataUpdateCoordinator(
         hass=hass,
         logger=_LOGGER,
         config_entry=config_entry,
         name=f"Leviton Decora Smart Wi-Fi ({data[CONF_NAME]})",
-        update_interval=timedelta(seconds=conf_scan_interval),
+        update_interval=timedelta(minutes=conf_scan_interval),
         update_method=async_update_data,
     )
     await coordinator.async_refresh()
@@ -166,7 +193,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     websocket = await _async_start_websocket(
         hass,
         config_entry,
-        api,
         coordinator,
         conf_residences,
         conf_devices,
@@ -182,24 +208,23 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 async def _async_start_websocket(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    api: LevitonAPI,
-    coordinator: DataUpdateCoordinator,
+    coordinator: LevitonDataUpdateCoordinator,
     conf_residences: list[int],
     conf_devices: list[int],
 ) -> LevitonWebSocket | None:
-    """Open the MyLeviton websocket using the bearer already in config.
+    """Open the MyLeviton WebSocket using the bearer already in config.
 
     We deliberately do NOT call ``LevitonAPI.login`` from this path:
     each re-login attempt counts toward Leviton's "too many failed
-    attempts" lockout, and a flapping websocket will burn through them.
+    attempts" lockout, and a flapping WebSocket will burn through them.
     Instead we synthesize the token payload from the bearer + user id
-    already persisted in the config entry. If that auth fails the WS
+    already persisted in the config entry. If that auth fails the WebSocket
     client backs off ``AUTH_FAILURE_COOLDOWN`` (1h) before any retry.
     """
     bearer = config_entry.data.get(CONF_TOKEN)
     user_id = config_entry.data.get(CONF_ID)
     if not bearer or not user_id:
-        _LOGGER.warning("Leviton websocket disabled: bearer/user id missing")
+        _LOGGER.warning("Leviton WebSocket disabled: bearer/user id missing")
         return None
 
     @callback
@@ -207,7 +232,7 @@ async def _async_start_websocket(
         # Re-read from config_entry on every reconnect so a re-auth via
         # the options flow propagates without an HA restart. Prefer the
         # full login response object captured at config-flow time — the
-        # cloud's WS auth historically needs the entire response, not
+        # cloud's WebSocket auth historically needs the entire response, not
         # just the bearer + user id.
         full = config_entry.data.get(CONF_LOGIN_RESPONSE)
         if isinstance(full, dict) and full.get("id"):
@@ -220,16 +245,27 @@ async def _async_start_websocket(
 
     @callback
     def on_notification(notification: dict) -> None:
-        if not isinstance(notification, dict):
-            return
-        hass.bus.async_fire(EVENT_NOTIFICATION, notification)
-        async_dispatcher_send(
-            hass, f"{SIGNAL_NOTIFICATION}_{config_entry.entry_id}", notification
-        )
+        if model_id := notification.get("modelId"):
+            for residence in coordinator.data.residences:
+                if residence.id in conf_residences:
+                    for device in residence.devices:
+                        if device.id in conf_devices and device.id == model_id:
+                            data = notification.get("data", {})
+                            device.data.update(
+                                {
+                                    key: value
+                                    for key, value in data.items()
+                                    if key in device.data
+                                }
+                            )
+            hass.bus.async_fire(EVENT_NOTIFICATION, notification)
+            async_dispatcher_send(
+                hass, f"{UPDATE_NOTIFICATION}_{model_id}", notification
+            )
 
     subs = _collect_subscriptions(coordinator, conf_residences, conf_devices)
     _LOGGER.debug(
-        "Leviton websocket: starting client with %d subscription(s)", len(subs)
+        "Leviton WebSocket: starting client with %d subscription(s)", len(subs)
     )
     websocket = LevitonWebSocket(
         session=async_get_clientsession(hass),
@@ -242,28 +278,29 @@ async def _async_start_websocket(
 
 
 def _collect_subscriptions(
-    coordinator: DataUpdateCoordinator,
+    coordinator: LevitonDataUpdateCoordinator,
     conf_residences: list[int],
     conf_devices: list[int],
 ) -> list[tuple[str, int]]:
-    """Build the list of (modelName, modelId) the WS should subscribe to.
+    """Build the list of (modelName, modelId) the WebSocket should subscribe to.
 
     Empirically the cloud delivers physical button presses on the parent
     IotSwitch as ``data.btnPress: [{button: N, trigger: T}]`` — there is
     no separate IotButton push channel, so we don't subscribe to one.
     """
-    subs: list[tuple[str, int]] = []
+    subscriptions: list[tuple[str, int]] = []
     data: LevitonData | None = coordinator.data
     if data is None:
-        return subs
+        return subscriptions
     for residence in data.residences:
-        if residence.id not in conf_residences:
-            continue
-        for device in residence.devices:
-            if device.id not in conf_devices:
-                continue
-            subs.append(("IotSwitch", device.id))
-    return subs
+        if residence.id in conf_residences:
+            subscriptions.extend(
+                ("IotSwitch", device.id)
+                for device in residence.devices
+                if device.id in conf_devices
+            )
+
+    return subscriptions
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -275,8 +312,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     if unload_ok:
         entry_data = hass.data[DOMAIN][config_entry.entry_id]
         entry_data[UNDO_UPDATE_LISTENER]()
-        websocket: LevitonWebSocket | None = entry_data.get(DATA_WEBSOCKET)
-        if websocket is not None:
+        if websocket := entry_data.get(DATA_WEBSOCKET):
             await websocket.stop()
         hass.data[DOMAIN].pop(config_entry.entry_id)
 
@@ -286,207 +322,3 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 async def async_update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Handle options update."""
     await hass.config_entries.async_reload(config_entry.entry_id)
-
-
-class LevitonEntity(CoordinatorEntity):
-    """Representation of a Leviton entity."""
-
-    def __init__(
-        self,
-        coordinator: DataUpdateCoordinator,
-        residence_id: int,
-        activity_id: int | None = None,
-        schedule_id: int | None = None,
-        room_id: int | None = None,
-        scene_id: int | None = None,
-        device_id: int | None = None,
-        button_id: int | None = None,
-        entity_description: EntityDescription | None = None,
-    ) -> None:
-        """Initialize the device."""
-        super().__init__(coordinator)
-        self.residence_id = residence_id
-        self.activity_id = activity_id
-        self.schedule_id = schedule_id
-        self.room_id = room_id
-        self.scene_id = scene_id
-        self.device_id = device_id
-        self.button_id = button_id
-        if entity_description:
-            self.entity_description = entity_description
-
-    @property
-    def residence(self) -> LevitonResidence | None:
-        """Return a LevitonResidence object."""
-        residences = {
-            residence.id: residence
-            for residence in self.coordinator.data.residences  # pyright: ignore[reportAttributeAccessIssue]
-        }
-        return residences.get(self.residence_id)
-
-    @property
-    def firmware(self) -> LevitonFirmware | None:
-        """Return a LevitonFirmware object."""
-        if self.device:
-            firmware = {
-                firmware.model: firmware
-                for firmware in self.coordinator.data.firmware  # pyright: ignore[reportAttributeAccessIssue]
-            }
-            return firmware.get(self.device.model)
-        return None
-
-    @property
-    def activity(self) -> LevitonActivity | None:
-        """Return a LevitonActivity object."""
-        if self.residence:
-            activities = {
-                activity.id: activity for activity in self.residence.activities
-            }
-            return activities.get(self.activity_id)
-        return None
-
-    @property
-    def schedule(self) -> LevitonSchedule | None:
-        """Return a LevitonSchedule object."""
-        if self.residence:
-            schedules = {schedule.id: schedule for schedule in self.residence.schedules}
-            return schedules.get(self.schedule_id)
-        return None
-
-    @property
-    def room(self) -> LevitonRoom | None:
-        """Return a LevitonRoom object."""
-        if self.residence:
-            rooms = {room.id: room for room in self.residence.rooms}
-            return rooms.get(self.room_id)
-        return None
-
-    @property
-    def scene(self) -> LevitonScene | None:
-        """Return a LevitonScene object."""
-        if self.room:
-            scenes = {scene.id: scene for scene in self.room.scenes}
-            return scenes.get(self.scene_id)
-        return None
-
-    @property
-    def device(self) -> LevitonDevice | None:
-        """Return a LevitonDevice object."""
-        if self.residence:
-            devices = {device.id: device for device in self.residence.devices}
-            return devices.get(self.device_id)
-        return None
-
-    @property
-    def button(self) -> LevitonButton | None:
-        """Return a LevitonButton object."""
-        if self.device:
-            buttons = {button.id: button for button in self.device.buttons}
-            return buttons.get(self.button_id)
-        return None
-
-    @property
-    def target(
-        self,
-    ) -> (
-        LevitonResidence
-        | LevitonActivity
-        | LevitonSchedule
-        | LevitonRoom
-        | LevitonScene
-        | LevitonDevice
-        | LevitonButton
-        | None
-    ):
-        """Return the target object."""
-        if self.button:
-            return self.button
-        if self.device:
-            return self.device
-        if self.scene:
-            return self.scene
-        if self.room:
-            return self.room
-        if self.schedule:
-            return self.schedule
-        if self.activity:
-            return self.activity
-        return self.residence
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        available = super().available
-        if self.device:
-            return all(
-                [
-                    available,
-                    self.device.is_connected,
-                ]
-            )
-        return available
-
-    @property
-    def device_info(self) -> dr.DeviceInfo | None:
-        """Return device specific attributes.
-
-        Implemented by platform classes.
-        """
-        if self.residence and self.residence.id:
-            if self.device and self.device.id:
-                return dr.DeviceInfo(
-                    configuration_url=CONFIGURATION_URL,
-                    identifiers={(DOMAIN, str(self.device.id))},
-                    manufacturer=self.device.manufacturer,
-                    model=self.device.model,
-                    name=self.device.name,
-                    serial_number=self.device.serial,
-                    suggested_area=self.device.room_name,
-                    sw_version=self.device.version,
-                    via_device=(DOMAIN, str(self.residence.id)),
-                )
-            return dr.DeviceInfo(
-                configuration_url=CONFIGURATION_URL,
-                entry_type=dr.DeviceEntryType.SERVICE,
-                identifiers={(DOMAIN, str(self.residence.id))},
-                manufacturer=DEVICE_INFO_MANUFACTURER,
-                model=DEVICE_INFO_MODEL_RESIDENCE,
-                name=self.residence.name,
-            )
-        return None
-
-    @property
-    def name(self) -> str | None:
-        """Return the name of the entity."""
-        name = self.residence.name if self.residence else None
-        if self.device:
-            name = self.device.name
-        if self.activity:
-            return f"{name} {self.activity.name} Activity"
-        if self.schedule:
-            return f"{name} {self.schedule.name} Schedule"
-        if self.scene:
-            return f"{name} {self.scene.name} Scene"
-        if self.button:
-            return f"{name} {self.button.text}"
-        if description := self.entity_description.name:
-            return f"{name} {description}"
-        return name
-
-    @property
-    def unique_id(self) -> str | int | None:
-        """Return a unique ID."""
-        unique_id = self.residence.id if self.residence else None
-        if self.device:
-            unique_id = self.device.mac
-        if self.activity:
-            return f"{unique_id}-{self.activity.id}"
-        if self.schedule:
-            return f"{unique_id}-{self.schedule.id}"
-        if self.scene and self.room:
-            return f"{unique_id}-{self.room.id}-{self.scene.id}"
-        if self.button:
-            return f"{unique_id}-{self.button.id}"
-        if key := self.entity_description.key:
-            return f"{unique_id}-{key}"
-        return unique_id

--- a/custom_components/leviton_decora_smart_wifi/api/__init__.py
+++ b/custom_components/leviton_decora_smart_wifi/api/__init__.py
@@ -74,6 +74,7 @@ class LevitonAPI:
         self.data: LevitonData = LevitonData()
         self.session = requests.Session()
         self.user_name: str | None = None
+        self.login_response: dict[str, Any] | None = None
 
     def call(
         self,
@@ -131,6 +132,7 @@ class LevitonAPI:
                     response["user"]["firstName"],
                     response["user"]["lastName"],
                 )
+                self.login_response = response
         except LevitonException as exception:
             if all(
                 [
@@ -178,8 +180,21 @@ class LevitonAPI:
         return text
 
     def refresh(self, function: Callable) -> requests.Response:
-        """Refresh login authorization."""
-        response = function()
+        """Refresh login authorization, retrying once on a stale connection.
+
+        Leviton's REST endpoint silently closes pooled keep-alive
+        connections; the next request on a stale connection fails with
+        ``ConnectionError``/``RemoteDisconnected`` and HA marks every
+        coordinator-bound entity unavailable until the next cycle. Retry
+        once after rotating the requests.Session so the client gets a
+        fresh socket.
+        """
+        try:
+            response = function()
+        except requests.exceptions.ConnectionError:
+            _LOGGER.debug("Leviton REST connection dropped; retrying with fresh session")
+            self.session = requests.Session()
+            response = function()
         if response.status_code != 200:
             text = json.loads(response.text)
             error = text["error"]

--- a/custom_components/leviton_decora_smart_wifi/api/__init__.py
+++ b/custom_components/leviton_decora_smart_wifi/api/__init__.py
@@ -1,8 +1,7 @@
 """Leviton API."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
+from http import HTTPMethod
 import json
 import logging
 from pathlib import Path
@@ -10,14 +9,7 @@ from typing import Any
 
 import requests
 
-from .const import (
-    API_ENDPOINT,
-    LOGIN_CODE_INVALID,
-    LOGIN_CODE_REQUIRED,
-    LOGIN_FAILED,
-    LOGIN_SUCCESS,
-    LOGIN_TOO_MANY_ATTEMPTS,
-)
+from .const import API_ENDPOINT, FIRMWARE_APP_MAP, FirmwareAppID, LoginResult
 from .firmware import Firmware
 from .residence import Residence
 
@@ -32,14 +24,14 @@ class LevitonData:
         self.data = data if data is not None else {}
 
     @property
+    def firmware(self) -> dict[str, Firmware]:
+        """Firmware."""
+        return self.data.get("firmware", {})
+
+    @property
     def residences(self) -> list[Residence]:
         """Residences."""
         return self.data.get("residences", [])
-
-    @property
-    def firmware(self) -> list[Firmware]:
-        """Firmware."""
-        return self.data.get("firmware", [])
 
 
 class LevitonException(Exception):
@@ -78,49 +70,34 @@ class LevitonAPI:
 
     def call(
         self,
-        method: str,
+        method: HTTPMethod,
         url: str,
         headers: dict | None = None,
         **kwargs,
     ) -> list[dict] | dict[str, Any] | None:
         """Call."""
-        if method not in ("get", "post", "put"):
-            return None
         if headers is None:
             headers = {}
         if self.authorization:
             headers["authorization"] = self.authorization
         _LOGGER.debug("Calling API with method: %s and URL: %s", method, url)
-        if method == "get":
-            response = self.refresh(
-                lambda: self.session.get(
-                    url=f"{API_ENDPOINT}/{url}", headers=headers, **kwargs
-                )
+        response = self.refresh(
+            lambda: self.session.request(
+                method=method, url=f"{API_ENDPOINT}/{url}", headers=headers, **kwargs
             )
-        if method == "post":
-            response = self.refresh(
-                lambda: self.session.post(
-                    url=f"{API_ENDPOINT}/{url}", headers=headers, **kwargs
-                )
-            )
-        if method == "put":
-            response = self.refresh(
-                lambda: self.session.put(
-                    url=f"{API_ENDPOINT}/{url}", headers=headers, **kwargs
-                )
-            )
+        )
         response = self.parse_response(response=response)
         self.save_response(response=response, name=url)
         return response
 
-    def login(self, email: str, password: str, code: str | None = None) -> str:
+    def login(self, email: str, password: str, code: str | None = None) -> LoginResult:
         """Login."""
         try:
             data = {"email": email, "password": password}
             if code:
                 data["code"] = code
             response = self.call(
-                method="post",
+                method=HTTPMethod.POST,
                 url="person/login",
                 params={"include": "user"},
                 data=data,
@@ -140,14 +117,14 @@ class LevitonAPI:
                     exception.message == "Login Failed",
                 ]
             ):
-                return LOGIN_FAILED
+                return LoginResult.FAILED
             if all(
                 [
                     exception.status_code == 403,
                     exception.message == "Too many failed attempts",
                 ]
             ):
-                return LOGIN_TOO_MANY_ATTEMPTS
+                return LoginResult.TOO_MANY_ATTEMPTS
             if all(
                 [
                     exception.status_code == 406,
@@ -155,17 +132,17 @@ class LevitonAPI:
                     == "Insufficient Data: Person uses two factor authentication. Requires code.",
                 ]
             ):
-                return LOGIN_CODE_REQUIRED
+                return LoginResult.CODE_REQUIRED
             if all(
                 [
                     exception.status_code == 408,
                     exception.message == "Error: Invalid code",
                 ]
             ):
-                return LOGIN_CODE_INVALID
-            return LOGIN_FAILED
+                return LoginResult.CODE_INVALID
+            return LoginResult.FAILED
         self.credentials = data
-        return LOGIN_SUCCESS
+        return LoginResult.SUCCESS
 
     def parse_response(self, response: requests.Response) -> dict[str, Any] | None:
         """Parse the response."""
@@ -192,7 +169,9 @@ class LevitonAPI:
         try:
             response = function()
         except requests.exceptions.ConnectionError:
-            _LOGGER.debug("Leviton REST connection dropped; retrying with fresh session")
+            _LOGGER.debug(
+                "Leviton REST connection dropped; retrying with fresh session"
+            )
             self.session = requests.Session()
             response = function()
         if response.status_code != 200:
@@ -250,14 +229,14 @@ class LevitonAPI:
         """Get residences."""
         data = []
         permissions = self.call(
-            method="get",
+            method=HTTPMethod.GET,
             url=f"person/{self.user_id}/residentialpermissions",
         )
         if permissions and isinstance(permissions, list):
             for permission in permissions:
                 residential_account_id = permission["residentialAccountId"]
                 residences = self.call(
-                    method="get",
+                    method=HTTPMethod.GET,
                     url=f"residentialaccounts/{residential_account_id}/residences",
                 )
                 if residences and isinstance(residences, list):
@@ -272,11 +251,11 @@ class LevitonAPI:
                                 ]
                             ):
                                 residence["activities"] = self.call(
-                                    method="get",
+                                    method=HTTPMethod.GET,
                                     url=f"residences/{residence_id}/residentialactivities",
                                 )
                                 residence["devices"] = self.call(
-                                    method="get",
+                                    method=HTTPMethod.GET,
                                     url=f"residences/{residence_id}/iotswitches",
                                     headers={
                                         "filter": json.dumps(
@@ -285,7 +264,7 @@ class LevitonAPI:
                                     },
                                 )
                                 residence["rooms"] = self.call(
-                                    method="get",
+                                    method=HTTPMethod.GET,
                                     url=f"residences/{residence_id}/residentialrooms",
                                     headers={
                                         "filter": json.dumps(
@@ -294,26 +273,27 @@ class LevitonAPI:
                                     },
                                 )
                                 residence["schedules"] = self.call(
-                                    method="get",
+                                    method=HTTPMethod.GET,
                                     url=f"residences/{residence_id}/residentialschedules",
                                 )
                                 data.append(Residence(self, residence))
         return data
 
-    def get_firmware(self, residences: list[Residence]) -> list[Firmware]:
+    def get_firmware(self, residences: list[Residence]) -> dict[str, Firmware]:
         """Get firmware."""
-        models = []
+        devices: dict[str, FirmwareAppID] = {}
         for residence in residences:
             for device in residence.devices:
-                if device.update_ready and device.model not in models:
-                    models.append(device.model)
-        firmware = []
-        for model in models:
-            model_firmware = self.call(
-                method="get",
+                if device.model and device.model not in devices:
+                    devices[device.model] = FIRMWARE_APP_MAP[device.generation]
+
+        firmware: dict[str, Firmware] = {}
+        for model, app_id in devices.items():
+            app_firmware = self.call(
+                method=HTTPMethod.GET,
                 url="lcsapps/getfirmware",
                 params={
-                    "appId": "DECORA_SMART_2",
+                    "appId": app_id,
                     "model": model,
                     "data": json.dumps(
                         {
@@ -322,6 +302,6 @@ class LevitonAPI:
                     ).encode("ascii"),
                 },
             )
-            if model_firmware and isinstance(model_firmware, list):
-                firmware.append(Firmware(model_firmware[0]))
+            if app_firmware and isinstance(app_firmware, list):
+                firmware[model] = Firmware(app_firmware[0])
         return firmware

--- a/custom_components/leviton_decora_smart_wifi/api/activity.py
+++ b/custom_components/leviton_decora_smart_wifi/api/activity.py
@@ -1,6 +1,6 @@
 """Leviton API."""
 
-from __future__ import annotations
+from http import HTTPMethod
 
 
 class Activity:
@@ -40,7 +40,7 @@ class Activity:
     def execute(self) -> None:
         """Execute."""
         self.api.call(
-            method="post",
+            method=HTTPMethod.POST,
             url="residentialactivities/execute",
             params={"id": self.id},
         )

--- a/custom_components/leviton_decora_smart_wifi/api/button.py
+++ b/custom_components/leviton_decora_smart_wifi/api/button.py
@@ -1,6 +1,6 @@
 """Leviton API."""
 
-from __future__ import annotations
+from http import HTTPMethod
 
 
 class Button:
@@ -45,7 +45,7 @@ class Button:
         for action in self.actions:
             for parameter in action.parameters:
                 self.api.call(
-                    method="post",
+                    method=HTTPMethod.POST,
                     url="residentialactivities/execute",
                     params={"id": parameter.value},
                 )

--- a/custom_components/leviton_decora_smart_wifi/api/const.py
+++ b/custom_components/leviton_decora_smart_wifi/api/const.py
@@ -4,16 +4,19 @@ from enum import IntEnum, StrEnum
 
 API_ENDPOINT = "https://my.leviton.com/api"
 
-LOGIN_CODE_INVALID = "login_code_invalid"
-LOGIN_CODE_REQUIRED = "login_code_required"
-LOGIN_FAILED = "login_failed"
-LOGIN_SUCCESS = "login_success"
-LOGIN_TOO_MANY_ATTEMPTS = "login_too_many_attempts"
-
-
 DEVICE_MODEL = "model"
 DEVICE_TYPE = "type"
 DEVICE_GENERATION = "generation"
+
+
+class LoginResult(StrEnum):
+    """Login result."""
+
+    CODE_INVALID = "code_invalid"
+    CODE_REQUIRED = "code_required"
+    FAILED = "failed"
+    SUCCESS = "success"
+    TOO_MANY_ATTEMPTS = "too_many_attempts"
 
 
 class ControlTiming(StrEnum):
@@ -485,3 +488,22 @@ STATUS_MAP = {
     "AWAY": Status.AWAY,
     "HOME": Status.HOME,
 }
+
+
+class FirmwareAppID(StrEnum):
+    """Firmware App ID."""
+
+    DECORA_SMART = "decora_smart"
+    DECORA_SMART_2 = "decora_smart_2"
+
+
+FIRMWARE_APP_MAP = {
+    DeviceGeneration.ONE: FirmwareAppID.DECORA_SMART,
+    DeviceGeneration.TWO: FirmwareAppID.DECORA_SMART_2,
+}
+
+
+class ReleaseURL(StrEnum):
+    """Release URL."""
+
+    GENERATION_TWO = "https://leviton.com/support/resources/product-support/decora-smart-support/decora-smart-wi-fi/decora-smart-wi-fi-2nd-generation-firmware-release-notes"

--- a/custom_components/leviton_decora_smart_wifi/api/device.py
+++ b/custom_components/leviton_decora_smart_wifi/api/device.py
@@ -1,10 +1,9 @@
 """Leviton API."""
 
-from __future__ import annotations
-
+from http import HTTPMethod
 import io
 import logging
-from typing import Literal
+from typing import Any, Literal
 
 import pyqrcode
 
@@ -30,6 +29,7 @@ from .const import (
     SUPPORTED_DEVICES_OUTLET,
     SUPPORTED_DEVICES_SWITCH,
     ControlTiming,
+    DeviceGeneration,
     DimmingMode,
     GFCIStatus,
     Level,
@@ -42,6 +42,7 @@ from .const import (
     StatusLEDMode,
     TimePeriod,
 )
+from .util import version_tuple
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,7 +54,7 @@ class Device:
         """Initialize."""
         self.api = api
         self.residence = residence
-        self.data = data
+        self.data: dict[str, Any] = data
 
     @property
     def name(self) -> str | None:
@@ -70,7 +71,7 @@ class Device:
         if value not in (Power.OFF, Power.ON):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"power": value},
         )
@@ -82,11 +83,11 @@ class Device:
 
     def turn_on(self) -> None:
         """Turn on."""
-        setattr(self, "power", Power.ON)
+        self.power = Power.ON
 
     def turn_off(self) -> None:
         """Turn off."""
-        setattr(self, "power", Power.OFF)
+        self.power = Power.OFF
 
     @property
     def brightness(self) -> int | None:
@@ -98,14 +99,14 @@ class Device:
         if not isinstance(value, int):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"power": Power.ON, "brightness": value},
         )
 
     def set_brightness(self, value: int) -> None:
         """Set brightness."""
-        setattr(self, "brightness", value)
+        self.brightness = value
 
     def set_speed(self, value: int) -> None:
         """Set speed."""
@@ -158,7 +159,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"minLevel": int(value), "maxLevel": self.max_level},
         )
@@ -190,7 +191,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"minLevel": self.min_level, "maxLevel": int(value)},
         )
@@ -263,7 +264,7 @@ class Device:
         if not isinstance(value, bool):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"isRandomEnabled": value},
         )
@@ -290,7 +291,7 @@ class Device:
         if value not in self.status_led_behavior_options:
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={
                 "statusLED": list(STATUS_LED_MODE_MAP.keys())[
@@ -314,7 +315,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"statusLED": StatusLED.ENABLED if value else StatusLED.DISABLED},
         )
@@ -346,7 +347,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={
                 "dimLED": list(DIM_LED_MAP.keys())[
@@ -389,7 +390,7 @@ class Device:
             return
         json_value = list(LOAD_TYPE_MAP.keys())[self.bulb_type_options.index(value)]
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"loadType": json_value},
         )
@@ -434,7 +435,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={
                 "fadeOffTime": list(FADE_ON_OFF_RATE_MAP.keys())[
@@ -454,7 +455,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={
                 "fadeOnTime": list(FADE_ON_OFF_RATE_MAP.keys())[
@@ -485,7 +486,7 @@ class Device:
             return
         _LOGGER.debug("[%s] Setting preset level to: %s%%", self.name, int(value))
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"presetLevel": int(value)},
         )
@@ -493,7 +494,7 @@ class Device:
     def identify(self) -> None:
         """Identify."""
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"identify": 10},
         )
@@ -525,7 +526,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={
                 "autoOffTime": list(AUTO_SHUTOFF_MAP.keys())[
@@ -560,7 +561,7 @@ class Device:
     def apply_update(self) -> None:
         """Apply update."""
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"apply_ota": 2},
         )
@@ -593,7 +594,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={
                 "triacOff": list(CONTROL_TIMING_MAP.keys())[
@@ -623,7 +624,7 @@ class Device:
             return
         _LOGGER.debug("[%s] Setting night preset level to: %s%%", self.name, int(value))
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"motionNightLevel": int(value)},
         )
@@ -651,7 +652,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={
                 "motionNightMode": list(MOTION_NIGHT_MODE_MAP.keys())[
@@ -680,7 +681,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"lightEnable": bool(value)},
         )
@@ -705,7 +706,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"motionDisable": (not bool(value))},
         )
@@ -725,7 +726,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"motionLED": value},
         )
@@ -753,7 +754,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={
                 "motionMode": list(MOTION_MODE_MAP.keys())[
@@ -785,7 +786,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={
                 "motionTimeout": list(MOTION_TIMEOUT_MAP.keys())[
@@ -835,7 +836,7 @@ class Device:
         ]:
             json = {"motionDisable": True, "motionDisableTime": json_value}
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json=json,
         )
@@ -854,7 +855,7 @@ class Device:
             "[%s] Setting motion ambient threshold to: %s%%", self.name, int(value)
         )
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"motionAmbientThr": int(value)},
         )
@@ -906,7 +907,7 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"enableBuzzer": bool(value)},
         )
@@ -916,7 +917,7 @@ class Device:
         if not self.is_gfci:
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"silenceBuzzer": True},
         )
@@ -949,9 +950,24 @@ class Device:
         ):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.residence.id}/iotswitches/{self.id}",
             json={"reversePhase": bool(value == DimmingMode.REVERSE)},
+        )
+
+    @property
+    def smart_bulb_mode_enabled(self) -> bool | None:
+        """Smart bulb mode enabled."""
+        return self.data.get("smartBulbModeEnabled")
+
+    @smart_bulb_mode_enabled.setter
+    def smart_bulb_mode_enabled(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            return
+        self.api.call(
+            method=HTTPMethod.PUT,
+            url=f"residences/{self.residence.id}/iotswitches/{self.id}",
+            json={"smartBulbModeEnabled": value},
         )
 
     @property
@@ -960,7 +976,7 @@ class Device:
         buttons = [
             Button(self.api, self, button) for button in self.data.get("iotButtons", [])
         ]
-        if self.is_generation_two:
+        if self.generation == DeviceGeneration.TWO:
             return [button for button in buttons if button.number != 4]
         return buttons
 
@@ -977,17 +993,7 @@ class Device:
     @property
     def is_fan(self) -> bool:
         """Is fan."""
-        return any(
-            [
-                self.model in SUPPORTED_DEVICES_FAN,
-                all(
-                    [
-                        self.model in SUPPORTED_DEVICES_SWITCH,
-                        self.name is not None and "fan" in self.name.lower(),
-                    ]
-                ),
-            ]
-        )
+        return bool(self.model in SUPPORTED_DEVICES_FAN)
 
     @property
     def is_gfci(self) -> bool:
@@ -997,44 +1003,26 @@ class Device:
     @property
     def is_light(self) -> bool:
         """Is light."""
-        return any(
-            [
-                self.model in SUPPORTED_DEVICES_LIGHT,
-                all(
-                    [
-                        self.model in SUPPORTED_DEVICES_SWITCH,
-                        self.name is not None and "light" in self.name.lower(),
-                    ]
-                ),
-            ]
-        )
+        return bool(self.model in SUPPORTED_DEVICES_LIGHT)
 
     @property
     def is_outlet(self) -> bool:
         """Is outlet."""
-        return all(
-            [
-                self.model in SUPPORTED_DEVICES_OUTLET,
-                not self.is_fan,
-                not self.is_light,
-            ]
-        )
+        return bool(self.model in SUPPORTED_DEVICES_OUTLET)
 
     @property
     def is_switch(self) -> bool:
         """Is switch."""
-        return all(
-            [
-                SUPPORTED_DEVICES_SWITCH,
-                not self.is_fan,
-                not self.is_light,
-            ]
-        )
+        return bool(self.model in SUPPORTED_DEVICES_SWITCH)
 
     @property
-    def is_generation_two(self) -> bool:
-        """Is second generation."""
-        return bool(self.model in SUPPORTED_DEVICES_GENERATION_TWO)
+    def generation(self) -> DeviceGeneration:
+        """Generation."""
+        return (
+            DeviceGeneration.TWO
+            if self.model in SUPPORTED_DEVICES_GENERATION_TWO
+            else DeviceGeneration.ONE
+        )
 
     @property
     def has_led_bar(self) -> bool:
@@ -1065,3 +1053,13 @@ class Device:
     def is_matter_capable(self) -> bool:
         """Is matter capable."""
         return bool(self._matter_qr_code)
+
+    @property
+    def is_smart_bulb_mode_capable(self) -> bool:
+        """Is smart bulb mode capable."""
+        return all(
+            [
+                self.version and version_tuple(self.version) >= version_tuple("1.6.9"),
+                self.model in ["D215S", "D2SCS", "D26HD", "D2MSD", "D2ELV"],
+            ]
+        )

--- a/custom_components/leviton_decora_smart_wifi/api/firmware.py
+++ b/custom_components/leviton_decora_smart_wifi/api/firmware.py
@@ -1,6 +1,6 @@
 """Leviton API."""
 
-from __future__ import annotations
+from .const import FirmwareAppID, ReleaseURL
 
 
 class Firmware:
@@ -9,6 +9,15 @@ class Firmware:
     def __init__(self, data) -> None:
         """Initialize."""
         self.data = data
+
+    @property
+    def app_id(self) -> FirmwareAppID | None:
+        """App ID."""
+        if lcs_app_id := self.data.get("lcsAppId"):
+            return {app_id.value: app_id for app_id in FirmwareAppID}[
+                lcs_app_id.lower()
+            ]
+        return None
 
     @property
     def enabled(self) -> bool | None:
@@ -24,6 +33,15 @@ class Firmware:
     def notes(self) -> str | None:
         """Notes."""
         return self.data.get("notes")
+
+    @property
+    def release_url(self) -> str | None:
+        """Release URL."""
+        return (
+            ReleaseURL.GENERATION_TWO
+            if self.app_id == FirmwareAppID.DECORA_SMART_2
+            else None
+        )
 
     @property
     def version(self) -> str | None:

--- a/custom_components/leviton_decora_smart_wifi/api/residence.py
+++ b/custom_components/leviton_decora_smart_wifi/api/residence.py
@@ -1,7 +1,6 @@
 """Leviton API."""
 
-from __future__ import annotations
-
+from http import HTTPMethod
 from typing import Literal
 
 from .activity import Activity
@@ -51,7 +50,7 @@ class Residence:
             return
         json_value = list(STATUS_MAP.keys())[list(STATUS_MAP.values()).index(value)]
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.id}",
             json={"status": json_value},
         )
@@ -59,20 +58,20 @@ class Residence:
     @property
     def is_away(self) -> bool:
         """Is away."""
-        return bool(self.status == "AWAY")
+        return bool(self.status == Status.HOME)
 
     @property
     def is_home(self) -> bool:
         """Is home."""
-        return bool(self.status == "HOME")
+        return bool(self.status == Status.HOME)
 
     def set_away(self) -> None:
         """Set away."""
-        setattr(self, "status", "AWAY")
+        self.status = Status.AWAY
 
     def set_home(self) -> None:
         """Set home."""
-        setattr(self, "status", "HOME")
+        self.status = Status.HOME
 
     @property
     def auto_update_enabled(self) -> bool | None:
@@ -84,7 +83,7 @@ class Residence:
         if not isinstance(value, bool):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.id}",
             json={"isAutoUpdateEnabled": value},
         )
@@ -99,7 +98,7 @@ class Residence:
         if not isinstance(value, bool):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.id}",
             json={"isRandomEnabled": value},
         )
@@ -194,7 +193,7 @@ class Residence:
         if not isinstance(value, bool):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.id}",
             json={"isOnHomeActivityEnabled": value},
         )
@@ -209,7 +208,7 @@ class Residence:
         if not isinstance(value, bool):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residences/{self.id}",
             json={"isOnAwayActivityEnabled": value},
         )
@@ -253,13 +252,13 @@ class Residence:
         target_activity_id = self.home_away_activity_map.get(value)
         if current_activity_id:
             self.api.call(
-                method="put",
+                method=HTTPMethod.PUT,
                 url=f"residentialactivities/{current_activity_id}",
                 json={"onHomeId": None},
             )
         if target_activity_id:
             self.api.call(
-                method="put",
+                method=HTTPMethod.PUT,
                 url=f"residentialactivities/{target_activity_id}",
                 json={"onHomeId": self.id},
             )
@@ -292,13 +291,13 @@ class Residence:
         target_activity_id = self.home_away_activity_map.get(value)
         if current_activity_id:
             self.api.call(
-                method="put",
+                method=HTTPMethod.PUT,
                 url=f"residentialactivities/{current_activity_id}",
                 json={"onAwayId": None},
             )
         if target_activity_id:
             self.api.call(
-                method="put",
+                method=HTTPMethod.PUT,
                 url=f"residentialactivities/{target_activity_id}",
                 json={"onAwayId": self.id},
             )

--- a/custom_components/leviton_decora_smart_wifi/api/room.py
+++ b/custom_components/leviton_decora_smart_wifi/api/room.py
@@ -1,7 +1,5 @@
 """Leviton API."""
 
-from __future__ import annotations
-
 from .scene import Scene
 
 

--- a/custom_components/leviton_decora_smart_wifi/api/scene.py
+++ b/custom_components/leviton_decora_smart_wifi/api/scene.py
@@ -1,6 +1,6 @@
 """Leviton API."""
 
-from __future__ import annotations
+from http import HTTPMethod
 
 
 class Scene:
@@ -25,7 +25,7 @@ class Scene:
     def execute(self) -> None:
         """Execute."""
         self.api.call(
-            method="post",
+            method=HTTPMethod.POST,
             url="residentialscenes/execute",
             params={"id": self.id},
         )

--- a/custom_components/leviton_decora_smart_wifi/api/schedule.py
+++ b/custom_components/leviton_decora_smart_wifi/api/schedule.py
@@ -1,6 +1,6 @@
 """Leviton API."""
 
-from __future__ import annotations
+from http import HTTPMethod
 
 
 class Schedule:
@@ -32,18 +32,18 @@ class Schedule:
         if not isinstance(value, bool):
             return
         self.api.call(
-            method="put",
+            method=HTTPMethod.PUT,
             url=f"residentialschedules/{self.id}",
             json={"disabled": bool(not value)},
         )
 
     def enable(self) -> None:
         """Enable."""
-        setattr(self, "enabled", True)
+        self.enabled = True
 
     def disable(self) -> None:
         """Disable."""
-        setattr(self, "enabled", False)
+        self.enabled = False
 
     @property
     def residence_id(self) -> int | None:

--- a/custom_components/leviton_decora_smart_wifi/api/util.py
+++ b/custom_components/leviton_decora_smart_wifi/api/util.py
@@ -1,0 +1,6 @@
+"""Leviton API."""
+
+
+def version_tuple(version):
+    "Version tuple."
+    return tuple(map(int, (version.split("."))))

--- a/custom_components/leviton_decora_smart_wifi/api/websocket.py
+++ b/custom_components/leviton_decora_smart_wifi/api/websocket.py
@@ -1,0 +1,247 @@
+"""Leviton MyLeviton cloud websocket client.
+
+Connects to ``wss://my.leviton.com/socket/websocket`` and subscribes to
+real-time push notifications. The protocol was reverse-engineered from
+the official myapp.leviton.com bundle (``authenticateSocketConnection``
+wired to ``onOpen``) and the homebridge-myleviton plugin.
+
+Auth model used here:
+- We do NOT call ``LevitonAPI.login`` from this client. The bearer token
+  already in the config entry is enough to synthesize a token payload.
+- If auth fails, we back off ``AUTH_FAILURE_COOLDOWN`` (default 1 hour)
+  before any retry, to avoid hammering Leviton's auth endpoint and
+  locking the account out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import aiohttp
+
+_LOGGER = logging.getLogger(__name__)
+
+WS_URL = "wss://my.leviton.com/socket/websocket"
+WS_ORIGIN = "https://my.leviton.com"
+
+PING_INTERVAL = 30.0
+
+# Reconnect when the network blip drops the WS — this is conservative.
+INITIAL_RECONNECT_DELAY = 30.0
+MAX_RECONNECT_DELAY = 600.0
+
+# Auth failure cooldown — long, so we never hammer Leviton even if the
+# token is bad. The integration's polling layer continues to work.
+AUTH_FAILURE_COOLDOWN = 3600.0
+
+CHALLENGE_TIMEOUT = 10.0
+
+
+class LevitonWebSocket:
+    """Persistent websocket subscriber for the MyLeviton cloud."""
+
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        token_provider: Callable[[], dict[str, Any] | None],
+        on_notification: Callable[[dict[str, Any]], None],
+    ) -> None:
+        self._session = session
+        self._token_provider = token_provider
+        self._on_notification = on_notification
+        self._subscriptions: list[tuple[str, int]] = []
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._task: asyncio.Task | None = None
+        self._stop = asyncio.Event()
+        self._ready = asyncio.Event()
+
+    def set_subscriptions(self, subs: list[tuple[str, int]]) -> None:
+        """Replace the subscription set; takes effect on next connect."""
+        self._subscriptions = list(subs)
+        if self._ready.is_set() and self._ws is not None and not self._ws.closed:
+            asyncio.create_task(self._send_subscriptions())
+
+    def start(self) -> None:
+        """Start the websocket loop as a background task."""
+        if self._task and not self._task.done():
+            return
+        self._stop.clear()
+        _LOGGER.debug("Leviton websocket task starting")
+        self._task = asyncio.create_task(self._run(), name="leviton_ws")
+
+    async def stop(self) -> None:
+        """Stop the websocket loop and close the connection."""
+        self._stop.set()
+        if self._ws is not None and not self._ws.closed:
+            await self._ws.close()
+        if self._task:
+            try:
+                await asyncio.wait_for(self._task, timeout=5.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                self._task.cancel()
+
+    async def _run(self) -> None:
+        delay = INITIAL_RECONNECT_DELAY
+        while not self._stop.is_set():
+            token = self._token_provider()
+            if not token or "id" not in token:
+                _LOGGER.error(
+                    "Leviton websocket: no token available; sleeping for %.0fs",
+                    AUTH_FAILURE_COOLDOWN,
+                )
+                await self._sleep_or_stop(AUTH_FAILURE_COOLDOWN)
+                continue
+
+            outcome = "transient"
+            try:
+                outcome = await self._connect(token)
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Leviton websocket loop error")
+            finally:
+                self._ready.clear()
+                self._ws = None
+
+            if outcome == "auth_failed":
+                _LOGGER.warning(
+                    "Leviton websocket auth failed; cooling down for %.0fs to avoid account lockout",
+                    AUTH_FAILURE_COOLDOWN,
+                )
+                await self._sleep_or_stop(AUTH_FAILURE_COOLDOWN)
+                delay = INITIAL_RECONNECT_DELAY
+                continue
+
+            if outcome == "ok":
+                delay = INITIAL_RECONNECT_DELAY
+
+            if not self._stop.is_set():
+                await self._sleep_or_stop(delay)
+                delay = min(delay * 2, MAX_RECONNECT_DELAY)
+
+    async def _sleep_or_stop(self, seconds: float) -> None:
+        try:
+            await asyncio.wait_for(self._stop.wait(), timeout=seconds)
+        except asyncio.TimeoutError:
+            pass
+
+    async def _connect(self, token: dict[str, Any]) -> str:
+        """Open the WS, authenticate, then run the receive loop.
+
+        Returns ``"ok"`` if we authenticated and ran cleanly,
+        ``"auth_failed"`` if auth was rejected (so the caller backs off
+        hard), or ``"transient"`` for any other failure.
+        """
+        _LOGGER.debug("Connecting to Leviton websocket %s", WS_URL)
+        headers = {"Origin": WS_ORIGIN}
+        try:
+            async with self._session.ws_connect(
+                WS_URL, headers=headers, heartbeat=PING_INTERVAL, autoclose=True
+            ) as ws:
+                self._ws = ws
+                auth_outcome = await self._authenticate(ws, token)
+                if auth_outcome != "ok":
+                    return auth_outcome
+                self._ready.set()
+                await self._send_subscriptions()
+                await self._receive_loop(ws)
+                return "ok"
+        except aiohttp.ClientError:
+            _LOGGER.warning("Leviton websocket connection error", exc_info=True)
+            return "transient"
+
+    async def _authenticate(
+        self,
+        ws: aiohttp.ClientWebSocketResponse,
+        token: dict[str, Any],
+    ) -> str:
+        """Authenticate the websocket.
+
+        Sends ``{token: <login response>}`` immediately on open per the
+        myapp.leviton.com client behavior. Waits up to a short window for
+        ``{type:"status", status:"ready"}``. Anything else (including the
+        ``challenge`` frame with a nonce or repeated ``status:"not ready"``)
+        is treated as info-level traffic and ignored — only an explicit
+        rejection or timeout drops auth to ``auth_failed``.
+        """
+        await ws.send_json({"token": token})
+        deadline = asyncio.get_running_loop().time() + CHALLENGE_TIMEOUT * 2
+
+        while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                _LOGGER.error("Websocket auth handshake timed out")
+                return "auth_failed"
+
+            try:
+                frame = await asyncio.wait_for(ws.receive(), timeout=remaining)
+            except asyncio.TimeoutError:
+                _LOGGER.error("Websocket auth handshake timed out")
+                return "auth_failed"
+
+            if frame.type is aiohttp.WSMsgType.TEXT:
+                try:
+                    payload = json.loads(frame.data)
+                except ValueError:
+                    _LOGGER.warning("Non-JSON handshake frame: %r", frame.data)
+                    continue
+                _LOGGER.debug("WS handshake frame: %s", payload)
+                if (
+                    payload.get("type") == "status"
+                    and payload.get("status") == "ready"
+                ):
+                    _LOGGER.info("Leviton websocket authenticated")
+                    return "ok"
+                continue
+
+            if frame.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING):
+                _LOGGER.error("WS closed during auth (code=%s)", getattr(frame, "data", None))
+                return "auth_failed"
+            if frame.type is aiohttp.WSMsgType.ERROR:
+                _LOGGER.error("WS error during auth: %s", ws.exception())
+                return "auth_failed"
+
+    async def _send_subscriptions(self) -> None:
+        if self._ws is None or self._ws.closed:
+            return
+        for model_name, model_id in self._subscriptions:
+            msg = {
+                "type": "subscribe",
+                "subscription": {"modelName": model_name, "modelId": model_id},
+            }
+            _LOGGER.debug("WS subscribe: %s", msg)
+            await self._ws.send_json(msg)
+
+    async def _receive_loop(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        async for msg in ws:
+            if self._stop.is_set():
+                break
+            if msg.type is aiohttp.WSMsgType.TEXT:
+                self._dispatch(msg.data)
+            elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING):
+                _LOGGER.debug("WS closed/closing")
+                break
+            elif msg.type is aiohttp.WSMsgType.ERROR:
+                _LOGGER.warning("WS error: %s", ws.exception())
+                break
+
+    def _dispatch(self, raw: str) -> None:
+        try:
+            payload = json.loads(raw)
+        except ValueError:
+            _LOGGER.warning("Non-JSON WS frame: %r", raw[:200])
+            return
+
+        msg_type = payload.get("type")
+        if msg_type == "notification":
+            _LOGGER.debug("WS notification: %s", json.dumps(payload, sort_keys=True))
+            try:
+                self._on_notification(payload.get("notification") or {})
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Notification handler raised")
+        else:
+            _LOGGER.debug("WS frame (type=%s): %s", msg_type, payload)

--- a/custom_components/leviton_decora_smart_wifi/api/websocket.py
+++ b/custom_components/leviton_decora_smart_wifi/api/websocket.py
@@ -1,4 +1,4 @@
-"""Leviton MyLeviton cloud websocket client.
+"""Leviton API.
 
 Connects to ``wss://my.leviton.com/socket/websocket`` and subscribes to
 real-time push notifications. The protocol was reverse-engineered from
@@ -13,12 +13,11 @@ Auth model used here:
   locking the account out.
 """
 
-from __future__ import annotations
-
 import asyncio
+from collections.abc import Callable
+import contextlib
 import json
 import logging
-from collections.abc import Callable
 from typing import Any
 
 import aiohttp
@@ -42,7 +41,7 @@ CHALLENGE_TIMEOUT = 10.0
 
 
 class LevitonWebSocket:
-    """Persistent websocket subscriber for the MyLeviton cloud."""
+    """Persistent WebSocket subscriber for the MyLeviton cloud."""
 
     def __init__(
         self,
@@ -50,6 +49,7 @@ class LevitonWebSocket:
         token_provider: Callable[[], dict[str, Any] | None],
         on_notification: Callable[[dict[str, Any]], None],
     ) -> None:
+        """Initialize."""
         self._session = session
         self._token_provider = token_provider
         self._on_notification = on_notification
@@ -63,25 +63,25 @@ class LevitonWebSocket:
         """Replace the subscription set; takes effect on next connect."""
         self._subscriptions = list(subs)
         if self._ready.is_set() and self._ws is not None and not self._ws.closed:
-            asyncio.create_task(self._send_subscriptions())
+            self._task = asyncio.create_task(self._send_subscriptions())
 
     def start(self) -> None:
-        """Start the websocket loop as a background task."""
+        """Start the WebSocket loop as a background task."""
         if self._task and not self._task.done():
             return
         self._stop.clear()
-        _LOGGER.debug("Leviton websocket task starting")
+        _LOGGER.debug("Leviton WebSocket task starting")
         self._task = asyncio.create_task(self._run(), name="leviton_ws")
 
     async def stop(self) -> None:
-        """Stop the websocket loop and close the connection."""
+        """Stop the WebSocket loop and close the connection."""
         self._stop.set()
         if self._ws is not None and not self._ws.closed:
             await self._ws.close()
         if self._task:
             try:
                 await asyncio.wait_for(self._task, timeout=5.0)
-            except (asyncio.TimeoutError, asyncio.CancelledError):
+            except TimeoutError, asyncio.CancelledError:
                 self._task.cancel()
 
     async def _run(self) -> None:
@@ -90,7 +90,7 @@ class LevitonWebSocket:
             token = self._token_provider()
             if not token or "id" not in token:
                 _LOGGER.error(
-                    "Leviton websocket: no token available; sleeping for %.0fs",
+                    "Leviton WebSocket: no token available; sleeping for %.0fs",
                     AUTH_FAILURE_COOLDOWN,
                 )
                 await self._sleep_or_stop(AUTH_FAILURE_COOLDOWN)
@@ -101,15 +101,15 @@ class LevitonWebSocket:
                 outcome = await self._connect(token)
             except asyncio.CancelledError:
                 raise
-            except Exception:  # noqa: BLE001
-                _LOGGER.exception("Leviton websocket loop error")
+            except Exception:
+                _LOGGER.exception("Leviton WebSocket loop error")
             finally:
                 self._ready.clear()
                 self._ws = None
 
             if outcome == "auth_failed":
                 _LOGGER.warning(
-                    "Leviton websocket auth failed; cooling down for %.0fs to avoid account lockout",
+                    "Leviton WebSocket auth failed; cooling down for %.0fs to avoid account lockout",
                     AUTH_FAILURE_COOLDOWN,
                 )
                 await self._sleep_or_stop(AUTH_FAILURE_COOLDOWN)
@@ -124,10 +124,8 @@ class LevitonWebSocket:
                 delay = min(delay * 2, MAX_RECONNECT_DELAY)
 
     async def _sleep_or_stop(self, seconds: float) -> None:
-        try:
+        with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(self._stop.wait(), timeout=seconds)
-        except asyncio.TimeoutError:
-            pass
 
     async def _connect(self, token: dict[str, Any]) -> str:
         """Open the WS, authenticate, then run the receive loop.
@@ -136,7 +134,7 @@ class LevitonWebSocket:
         ``"auth_failed"`` if auth was rejected (so the caller backs off
         hard), or ``"transient"`` for any other failure.
         """
-        _LOGGER.debug("Connecting to Leviton websocket %s", WS_URL)
+        _LOGGER.debug("Connecting to Leviton WebSocket %s", WS_URL)
         headers = {"Origin": WS_ORIGIN}
         try:
             async with self._session.ws_connect(
@@ -151,7 +149,7 @@ class LevitonWebSocket:
                 await self._receive_loop(ws)
                 return "ok"
         except aiohttp.ClientError:
-            _LOGGER.warning("Leviton websocket connection error", exc_info=True)
+            _LOGGER.warning("Leviton WebSocket connection error", exc_info=True)
             return "transient"
 
     async def _authenticate(
@@ -159,7 +157,7 @@ class LevitonWebSocket:
         ws: aiohttp.ClientWebSocketResponse,
         token: dict[str, Any],
     ) -> str:
-        """Authenticate the websocket.
+        """Authenticate the WebSocket.
 
         Sends ``{token: <login response>}`` immediately on open per the
         myapp.leviton.com client behavior. Waits up to a short window for
@@ -174,13 +172,13 @@ class LevitonWebSocket:
         while True:
             remaining = deadline - asyncio.get_running_loop().time()
             if remaining <= 0:
-                _LOGGER.error("Websocket auth handshake timed out")
+                _LOGGER.error("WebSocket auth handshake timed out")
                 return "auth_failed"
 
             try:
                 frame = await asyncio.wait_for(ws.receive(), timeout=remaining)
-            except asyncio.TimeoutError:
-                _LOGGER.error("Websocket auth handshake timed out")
+            except TimeoutError:
+                _LOGGER.error("WebSocket auth handshake timed out")
                 return "auth_failed"
 
             if frame.type is aiohttp.WSMsgType.TEXT:
@@ -189,20 +187,20 @@ class LevitonWebSocket:
                 except ValueError:
                     _LOGGER.warning("Non-JSON handshake frame: %r", frame.data)
                     continue
-                _LOGGER.debug("WS handshake frame: %s", payload)
-                if (
-                    payload.get("type") == "status"
-                    and payload.get("status") == "ready"
-                ):
-                    _LOGGER.info("Leviton websocket authenticated")
+                _LOGGER.debug("WebSocket handshake frame: %s", payload)
+                if payload.get("type") == "status" and payload.get("status") == "ready":
+                    _LOGGER.info("Leviton WebSocket authenticated")
                     return "ok"
                 continue
 
             if frame.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING):
-                _LOGGER.error("WS closed during auth (code=%s)", getattr(frame, "data", None))
+                _LOGGER.error(
+                    "WebSocket closed during auth (code=%s)",
+                    getattr(frame, "data", None),
+                )
                 return "auth_failed"
             if frame.type is aiohttp.WSMsgType.ERROR:
-                _LOGGER.error("WS error during auth: %s", ws.exception())
+                _LOGGER.error("WebSocket error during auth: %s", ws.exception())
                 return "auth_failed"
 
     async def _send_subscriptions(self) -> None:
@@ -213,7 +211,7 @@ class LevitonWebSocket:
                 "type": "subscribe",
                 "subscription": {"modelName": model_name, "modelId": model_id},
             }
-            _LOGGER.debug("WS subscribe: %s", msg)
+            _LOGGER.debug("WebSocket subscribe: %s", msg)
             await self._ws.send_json(msg)
 
     async def _receive_loop(self, ws: aiohttp.ClientWebSocketResponse) -> None:
@@ -223,10 +221,10 @@ class LevitonWebSocket:
             if msg.type is aiohttp.WSMsgType.TEXT:
                 self._dispatch(msg.data)
             elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING):
-                _LOGGER.debug("WS closed/closing")
+                _LOGGER.debug("WebSocket closed/closing")
                 break
             elif msg.type is aiohttp.WSMsgType.ERROR:
-                _LOGGER.warning("WS error: %s", ws.exception())
+                _LOGGER.warning("WebSocket error: %s", ws.exception())
                 break
 
     def _dispatch(self, raw: str) -> None:
@@ -238,10 +236,12 @@ class LevitonWebSocket:
 
         msg_type = payload.get("type")
         if msg_type == "notification":
-            _LOGGER.debug("WS notification: %s", json.dumps(payload, sort_keys=True))
+            _LOGGER.debug(
+                "WebSocket notification: %s", json.dumps(payload, sort_keys=True)
+            )
             try:
                 self._on_notification(payload.get("notification") or {})
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _LOGGER.exception("Notification handler raised")
         else:
-            _LOGGER.debug("WS frame (type=%s): %s", msg_type, payload)
+            _LOGGER.debug("WebSocket frame (type=%s): %s", msg_type, payload)

--- a/custom_components/leviton_decora_smart_wifi/binary_sensor.py
+++ b/custom_components/leviton_decora_smart_wifi/binary_sensor.py
@@ -1,7 +1,5 @@
 """Support for Leviton Decora Smart Wi-Fi binary sensor entities."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -15,8 +13,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import LevitonEntity
 from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN
+from .entity import LevitonEntity
 
 
 @dataclass(frozen=True)

--- a/custom_components/leviton_decora_smart_wifi/button.py
+++ b/custom_components/leviton_decora_smart_wifi/button.py
@@ -1,7 +1,5 @@
 """Support for Leviton Decora Smart Wi-Fi button entities."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -16,8 +14,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import LevitonEntity
 from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN
+from .entity import LevitonEntity
 
 
 @dataclass(frozen=True)

--- a/custom_components/leviton_decora_smart_wifi/config_flow.py
+++ b/custom_components/leviton_decora_smart_wifi/config_flow.py
@@ -39,6 +39,7 @@ from .api import (
 )
 from .const import (
     CONF_DEVICES,
+    CONF_LOGIN_RESPONSE,
     CONF_RESIDENCES,
     CONF_SAVE_RESPONSES,
     CONF_TIMEOUT,
@@ -83,6 +84,8 @@ class LevitonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.user_input[CONF_ID] = self.api.user_id
         self.user_input[CONF_NAME] = self.api.user_name
         self.user_input[CONF_TOKEN] = self.api.authorization
+        if self.api.login_response is not None:
+            self.user_input[CONF_LOGIN_RESPONSE] = self.api.login_response
 
         return await self.async_step_residences()
 

--- a/custom_components/leviton_decora_smart_wifi/config_flow.py
+++ b/custom_components/leviton_decora_smart_wifi/config_flow.py
@@ -30,13 +30,8 @@ from homeassistant.helpers.selector import (
     TextSelectorType,
 )
 
-from .api import (
-    LOGIN_CODE_REQUIRED,
-    LOGIN_SUCCESS,
-    LevitonAPI,
-    LevitonData,
-    LevitonException,
-)
+from .api import LevitonAPI, LevitonData, LevitonException
+from .api.const import LoginResult as LevitonLoginResult
 from .const import (
     CONF_DEVICES,
     CONF_LOGIN_RESPONSE,
@@ -56,7 +51,7 @@ _LOGGER = logging.getLogger(__name__)
 class LevitonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Leviton Decora Smart Wi-Fi integration."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self) -> None:
@@ -104,10 +99,10 @@ class LevitonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.user_input[CONF_PASSWORD],
             )
 
-            if result == LOGIN_CODE_REQUIRED:
+            if result == LevitonLoginResult.CODE_REQUIRED:
                 _LOGGER.debug("Two factor authentication is required for the account")
                 return await self.async_step_authenticate()
-            if result == LOGIN_SUCCESS:
+            if result == LevitonLoginResult.SUCCESS:
                 _LOGGER.debug("Login successful")
                 return await self.async_finish_login(errors)
             errors["base"] = result
@@ -146,7 +141,7 @@ class LevitonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.user_input[CONF_CODE],
             )
 
-            if result == LOGIN_SUCCESS:
+            if result == LevitonLoginResult.SUCCESS:
                 _LOGGER.debug("Login successful")
                 return await self.async_finish_login(errors)
             errors["base"] = result
@@ -223,11 +218,7 @@ class LevitonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if self.index == len(self.user_input[CONF_RESIDENCES]):
             self.index = 0
-            if self.show_advanced_options:
-                return await self.async_step_advanced()
-            return self.async_create_entry(
-                title=self.config_title, data=self.user_input
-            )
+            return await self.async_step_advanced()
 
         for residence in self.response.residences:
             if residence.id == self.user_input[CONF_RESIDENCES][self.index]:
@@ -283,7 +274,7 @@ class LevitonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             min=ScanInterval.MIN,
                             max=ScanInterval.MAX,
                             step=ScanInterval.STEP,
-                            unit_of_measurement=UnitOfTime.SECONDS,
+                            unit_of_measurement=UnitOfTime.MINUTES,
                         )
                     ),
                     vol.Optional(CONF_TIMEOUT, default=Timeout.DEFAULT): NumberSelector(
@@ -390,9 +381,7 @@ class LevitonOptionsFlowHandler(config_entries.OptionsFlow):
                     self.index += 1
 
         if self.index == len(self.user_input[CONF_RESIDENCES]):
-            if self.show_advanced_options:
-                return await self.async_step_advanced()
-            return self.async_create_entry(title="", data=self.user_input)
+            return await self.async_step_advanced()
         if self.index == 0:
             self.user_input[CONF_DEVICES] = []
 
@@ -460,7 +449,7 @@ class LevitonOptionsFlowHandler(config_entries.OptionsFlow):
                             min=ScanInterval.MIN,
                             max=ScanInterval.MAX,
                             step=ScanInterval.STEP,
-                            unit_of_measurement=UnitOfTime.SECONDS,
+                            unit_of_measurement=UnitOfTime.MINUTES,
                         )
                     ),
                     vol.Optional(CONF_TIMEOUT, default=conf_timeout): NumberSelector(

--- a/custom_components/leviton_decora_smart_wifi/const.py
+++ b/custom_components/leviton_decora_smart_wifi/const.py
@@ -11,8 +11,16 @@ CONFIGURATION_URL: str = "https://my.leviton.com/home"
 
 DATA_API: str = "api"
 DATA_COORDINATOR: str = "coordinator"
+DATA_WEBSOCKET: str = "websocket"
+
+CONF_LOGIN_RESPONSE: str = "login_response"
 
 DOMAIN: str = "leviton_decora_smart_wifi"
+
+EVENT_NOTIFICATION: str = f"{DOMAIN}_notification"
+EVENT_BUTTON_PRESSED: str = f"{DOMAIN}_button_pressed"
+
+SIGNAL_NOTIFICATION: str = f"{DOMAIN}_notification_signal"
 
 RELEASE_URL: str = "https://leviton.com/support/resources/product-support/decora-smart-support/decora-smart-wi-fi/decora-smart-wi-fi-2nd-generation-firmware-release-notes"
 

--- a/custom_components/leviton_decora_smart_wifi/const.py
+++ b/custom_components/leviton_decora_smart_wifi/const.py
@@ -17,12 +17,8 @@ CONF_LOGIN_RESPONSE: str = "login_response"
 
 DOMAIN: str = "leviton_decora_smart_wifi"
 
-EVENT_NOTIFICATION: str = f"{DOMAIN}_notification"
-EVENT_BUTTON_PRESSED: str = f"{DOMAIN}_button_pressed"
-
-SIGNAL_NOTIFICATION: str = f"{DOMAIN}_notification_signal"
-
-RELEASE_URL: str = "https://leviton.com/support/resources/product-support/decora-smart-support/decora-smart-wi-fi/decora-smart-wi-fi-2nd-generation-firmware-release-notes"
+EVENT_NOTIFICATION: str = f"{DOMAIN}_event"
+UPDATE_NOTIFICATION: str = f"{DOMAIN}_update"
 
 UNDO_UPDATE_LISTENER: str = "undo_update_listener"
 
@@ -36,10 +32,10 @@ DEVICE_INFO_MODEL_RESIDENCE: str = "Residence"
 class ScanInterval(IntEnum):
     """Scan interval."""
 
-    DEFAULT = 120
-    MAX = 600
-    MIN = 30
-    STEP = 30
+    DEFAULT = 10
+    MAX = 60
+    MIN = 1
+    STEP = 1
 
 
 class Timeout(IntEnum):

--- a/custom_components/leviton_decora_smart_wifi/entity.py
+++ b/custom_components/leviton_decora_smart_wifi/entity.py
@@ -1,0 +1,245 @@
+"""Base class for Leviton Decora Smart Wi-Fi entities."""
+
+from typing import Any
+
+from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import LevitonDataUpdateCoordinator
+from .api.activity import Activity as LevitonActivity
+from .api.button import Button as LevitonButton
+from .api.device import Device as LevitonDevice
+from .api.firmware import Firmware as LevitonFirmware
+from .api.residence import Residence as LevitonResidence
+from .api.room import Room as LevitonRoom
+from .api.scene import Scene as LevitonScene
+from .api.schedule import Schedule as LevitonSchedule
+from .const import (
+    CONFIGURATION_URL,
+    DEVICE_INFO_MANUFACTURER,
+    DEVICE_INFO_MODEL_RESIDENCE,
+    DOMAIN,
+    UPDATE_NOTIFICATION,
+)
+
+
+class LevitonEntity(CoordinatorEntity[LevitonDataUpdateCoordinator]):
+    """Representation of a Leviton entity."""
+
+    def __init__(
+        self,
+        coordinator: LevitonDataUpdateCoordinator,
+        residence_id: int,
+        activity_id: int | None = None,
+        schedule_id: int | None = None,
+        room_id: int | None = None,
+        scene_id: int | None = None,
+        device_id: int | None = None,
+        button_id: int | None = None,
+        entity_description: EntityDescription | None = None,
+    ) -> None:
+        """Initialize the device."""
+        super().__init__(coordinator)
+        self.residence_id = residence_id
+        self.activity_id = activity_id
+        self.schedule_id = schedule_id
+        self.room_id = room_id
+        self.scene_id = scene_id
+        self.device_id = device_id
+        self.button_id = button_id
+        if entity_description:
+            self.entity_description = entity_description
+
+    @property
+    def residence(self) -> LevitonResidence | None:
+        """Return a LevitonResidence object."""
+        residences = {
+            residence.id: residence for residence in self.coordinator.data.residences
+        }
+        return residences.get(self.residence_id)
+
+    @property
+    def firmware(self) -> LevitonFirmware | None:
+        """Return a LevitonFirmware object."""
+        if self.device and self.device.model:
+            return self.coordinator.data.firmware.get(self.device.model)
+        return None
+
+    @property
+    def activity(self) -> LevitonActivity | None:
+        """Return a LevitonActivity object."""
+        if self.residence:
+            activities = {
+                activity.id: activity for activity in self.residence.activities
+            }
+            return activities.get(self.activity_id)
+        return None
+
+    @property
+    def schedule(self) -> LevitonSchedule | None:
+        """Return a LevitonSchedule object."""
+        if self.residence:
+            schedules = {schedule.id: schedule for schedule in self.residence.schedules}
+            return schedules.get(self.schedule_id)
+        return None
+
+    @property
+    def room(self) -> LevitonRoom | None:
+        """Return a LevitonRoom object."""
+        if self.residence:
+            rooms = {room.id: room for room in self.residence.rooms}
+            return rooms.get(self.room_id)
+        return None
+
+    @property
+    def scene(self) -> LevitonScene | None:
+        """Return a LevitonScene object."""
+        if self.room:
+            scenes = {scene.id: scene for scene in self.room.scenes}
+            return scenes.get(self.scene_id)
+        return None
+
+    @property
+    def device(self) -> LevitonDevice | None:
+        """Return a LevitonDevice object."""
+        if self.residence:
+            devices = {device.id: device for device in self.residence.devices}
+            return devices.get(self.device_id)
+        return None
+
+    @property
+    def button(self) -> LevitonButton | None:
+        """Return a LevitonButton object."""
+        if self.device:
+            buttons = {button.id: button for button in self.device.buttons}
+            return buttons.get(self.button_id)
+        return None
+
+    @property
+    def target(
+        self,
+    ) -> (
+        LevitonResidence
+        | LevitonActivity
+        | LevitonSchedule
+        | LevitonRoom
+        | LevitonScene
+        | LevitonDevice
+        | LevitonButton
+        | None
+    ):
+        """Return the target object."""
+        if self.button:
+            return self.button
+        if self.device:
+            return self.device
+        if self.scene:
+            return self.scene
+        if self.room:
+            return self.room
+        if self.schedule:
+            return self.schedule
+        if self.activity:
+            return self.activity
+        return self.residence
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        available = super().available
+        if self.device:
+            return all(
+                [
+                    available,
+                    self.device.is_connected,
+                ]
+            )
+        return available
+
+    @property
+    def device_info(self) -> dr.DeviceInfo | None:
+        """Return device specific attributes.
+
+        Implemented by platform classes.
+        """
+        if self.residence and self.residence.id:
+            if self.device and self.device.id:
+                return dr.DeviceInfo(
+                    configuration_url=CONFIGURATION_URL,
+                    identifiers={(DOMAIN, str(self.device.id))},
+                    manufacturer=self.device.manufacturer,
+                    model=self.device.model,
+                    name=self.device.name,
+                    serial_number=self.device.serial,
+                    suggested_area=self.device.room_name,
+                    sw_version=self.device.version,
+                    via_device=(DOMAIN, str(self.residence.id)),
+                )
+            return dr.DeviceInfo(
+                configuration_url=CONFIGURATION_URL,
+                entry_type=dr.DeviceEntryType.SERVICE,
+                identifiers={(DOMAIN, str(self.residence.id))},
+                manufacturer=DEVICE_INFO_MANUFACTURER,
+                model=DEVICE_INFO_MODEL_RESIDENCE,
+                name=self.residence.name,
+            )
+        return None
+
+    @property
+    def name(self) -> str | None:
+        """Return the name of the entity."""
+        name = self.residence.name if self.residence else None
+        if self.device:
+            name = self.device.name
+        if self.activity:
+            return f"{name} {self.activity.name} Activity"
+        if self.schedule:
+            return f"{name} {self.schedule.name} Schedule"
+        if self.scene:
+            return f"{name} {self.scene.name} Scene"
+        if self.button:
+            return f"{name} {self.button.text}"
+        if description := self.entity_description.name:
+            return f"{name} {description}"
+        return name
+
+    @property
+    def unique_id(self) -> str | int | None:
+        """Return a unique ID."""
+        unique_id = self.residence.id if self.residence else None
+        if self.device:
+            unique_id = self.device.mac
+        if self.activity:
+            return f"{unique_id}-{self.activity.id}"
+        if self.schedule:
+            return f"{unique_id}-{self.schedule.id}"
+        if self.scene and self.room:
+            return f"{unique_id}-{self.room.id}-{self.scene.id}"
+        if self.button:
+            return f"{unique_id}-{self.button.id}"
+        if key := self.entity_description.key:
+            return f"{unique_id}-{key}"
+        return unique_id
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass.
+
+        To be extended by integrations.
+        """
+        await super().async_added_to_hass()
+        if self.device and self.device.id:
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    self.hass,
+                    f"{UPDATE_NOTIFICATION}_{self.device.id}",
+                    self.handle_notification,
+                )
+            )
+
+    @callback
+    def handle_notification(self, notification: dict[str, Any]) -> None:
+        """Handle notification."""
+        self.async_write_ha_state()

--- a/custom_components/leviton_decora_smart_wifi/event.py
+++ b/custom_components/leviton_decora_smart_wifi/event.py
@@ -1,29 +1,26 @@
-"""Event entities for Leviton Decora Smart Wi-Fi controller buttons.
+"""Support for Leviton Decora Smart Wi-Fi event entities."""
 
-Surfaces real-time button presses delivered over the MyLeviton cloud
-websocket. Each controller button becomes an `event` entity that fires
-when the cloud pushes a notification for it.
-"""
-
-from __future__ import annotations
-
-import logging
+from dataclasses import dataclass
 from typing import Any
 
-from homeassistant.components.event import EventDeviceClass, EventEntity
+from homeassistant.components.event import (
+    EventDeviceClass,
+    EventEntity,
+    EventEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import LevitonEntity
-from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN, SIGNAL_NOTIFICATION
-
-_LOGGER = logging.getLogger(__name__)
+from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN
+from .entity import LevitonEntity
 
 EVENT_TYPE_PRESS = "press"
 
-EVENT_TYPES = [EVENT_TYPE_PRESS]
+
+@dataclass(frozen=True)
+class LevitonEventEntityDescription(EventEntityDescription):
+    """Class to describe a Leviton Decora Smart Wi-Fi event entity."""
 
 
 async def async_setup_entry(
@@ -43,23 +40,25 @@ async def async_setup_entry(
         return
 
     for residence in coordinator.data.residences:
-        if residence.id not in conf_residences:
-            continue
-        for device in residence.devices:
-            if device.id not in conf_devices:
-                continue
-            if not getattr(device, "is_controller", False):
-                continue
-            for button in getattr(device, "buttons", []) or []:
-                entities.append(
-                    LevitonButtonEvent(
-                        coordinator=coordinator,
-                        residence_id=residence.id,
-                        device_id=device.id,
-                        button_id=button.id,
-                        config_entry_id=config_entry.entry_id,
+        if residence.id in conf_residences:
+            for device in residence.devices:
+                if device.id in conf_devices:
+                    entities.extend(
+                        LevitonButtonEvent(
+                            coordinator=coordinator,
+                            residence_id=residence.id,
+                            device_id=device.id,
+                            button_id=button.id,
+                            entity_description=LevitonEventEntityDescription(
+                                key="event",
+                                name=None,
+                                device_class=EventDeviceClass.BUTTON,
+                                event_types=[EVENT_TYPE_PRESS],
+                            ),
+                        )
+                        for button in device.buttons
+                        if device.is_controller
                     )
-                )
 
     async_add_entities(entities)
 
@@ -67,48 +66,10 @@ async def async_setup_entry(
 class LevitonButtonEvent(LevitonEntity, EventEntity):
     """Event entity that fires when a controller button is pressed."""
 
-    _attr_device_class = EventDeviceClass.BUTTON
-    _attr_event_types = EVENT_TYPES
-    _attr_has_entity_name = True
-    _attr_translation_key = "button_press"
-
-    def __init__(
-        self,
-        coordinator,
-        residence_id: int,
-        device_id: int,
-        button_id: int,
-        config_entry_id: str,
-    ) -> None:
-        super().__init__(
-            coordinator=coordinator,
-            residence_id=residence_id,
-            device_id=device_id,
-            button_id=button_id,
-        )
-        self._config_entry_id = config_entry_id
-
-    @property
-    def name(self) -> str | None:
-        if self.button:
-            return f"{self.button.text} press"
-        return None
-
-    @property
-    def unique_id(self) -> str | None:
-        if self.device and self.button:
-            return f"{self.device.mac}-{self.button.id}-event"
-        return None
-
-    async def async_added_to_hass(self) -> None:
-        await super().async_added_to_hass()
-        signal = f"{SIGNAL_NOTIFICATION}_{self._config_entry_id}"
-        self.async_on_remove(
-            async_dispatcher_connect(self.hass, signal, self._handle_notification)
-        )
+    entity_description: LevitonEventEntityDescription
 
     @callback
-    def _handle_notification(self, notification: dict[str, Any]) -> None:
+    def handle_notification(self, notification: dict[str, Any]) -> None:
         """Fire ``press`` when the cloud reports our button was pressed.
 
         Empirical wire format on the parent IotSwitch::
@@ -123,34 +84,23 @@ class LevitonButtonEvent(LevitonEntity, EventEntity):
         (``1`` is the only value seen so far; the attribute is preserved
         verbatim so users can branch on it once more values are observed).
         """
-        if not isinstance(notification, dict):
-            return
-        if notification.get("modelName") != "IotSwitch":
-            return
-        if notification.get("modelId") != self.device_id:
-            return
-
-        data = notification.get("data") or {}
-        presses = data.get("btnPress") if isinstance(data, dict) else None
-        if not isinstance(presses, list):
-            return
-
-        button_number = self.button.number if self.button else None
-        if button_number is None:
-            return
-
-        for press in presses:
-            if not isinstance(press, dict):
-                continue
-            if press.get("button") != button_number:
-                continue
-            self._trigger_event(
-                EVENT_TYPE_PRESS,
-                {
-                    "trigger": press.get("trigger"),
-                    "button": press.get("button"),
-                    "lastUpdated": data.get("lastUpdated"),
-                    "rssi": data.get("rssi"),
-                },
-            )
+        if (
+            self.device
+            and self.device.id
+            and notification.get("modelId") == self.device.id
+        ):
+            data = notification.get("data", {})
+            for button_press in data.get("btnPress", []):
+                if (
+                    self.button
+                    and self.button.number
+                    and button_press.get("button") == self.button.number
+                ):
+                    self._trigger_event(
+                        EVENT_TYPE_PRESS,
+                        {
+                            "button": button_press.get("button"),
+                            "trigger": button_press.get("trigger"),
+                        },
+                    )
             self.async_write_ha_state()

--- a/custom_components/leviton_decora_smart_wifi/event.py
+++ b/custom_components/leviton_decora_smart_wifi/event.py
@@ -1,0 +1,156 @@
+"""Event entities for Leviton Decora Smart Wi-Fi controller buttons.
+
+Surfaces real-time button presses delivered over the MyLeviton cloud
+websocket. Each controller button becomes an `event` entity that fires
+when the cloud pushes a notification for it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.event import EventDeviceClass, EventEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import LevitonEntity
+from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN, SIGNAL_NOTIFICATION
+
+_LOGGER = logging.getLogger(__name__)
+
+EVENT_TYPE_PRESS = "press"
+
+EVENT_TYPES = [EVENT_TYPE_PRESS]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up event entities for each configured controller button."""
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = entry_data[DATA_COORDINATOR]
+    conf_residences = entry_data[CONF_RESIDENCES]
+    conf_devices = entry_data[CONF_DEVICES]
+
+    entities: list[LevitonButtonEvent] = []
+    if coordinator.data is None:
+        async_add_entities(entities)
+        return
+
+    for residence in coordinator.data.residences:
+        if residence.id not in conf_residences:
+            continue
+        for device in residence.devices:
+            if device.id not in conf_devices:
+                continue
+            if not getattr(device, "is_controller", False):
+                continue
+            for button in getattr(device, "buttons", []) or []:
+                entities.append(
+                    LevitonButtonEvent(
+                        coordinator=coordinator,
+                        residence_id=residence.id,
+                        device_id=device.id,
+                        button_id=button.id,
+                        config_entry_id=config_entry.entry_id,
+                    )
+                )
+
+    async_add_entities(entities)
+
+
+class LevitonButtonEvent(LevitonEntity, EventEntity):
+    """Event entity that fires when a controller button is pressed."""
+
+    _attr_device_class = EventDeviceClass.BUTTON
+    _attr_event_types = EVENT_TYPES
+    _attr_has_entity_name = True
+    _attr_translation_key = "button_press"
+
+    def __init__(
+        self,
+        coordinator,
+        residence_id: int,
+        device_id: int,
+        button_id: int,
+        config_entry_id: str,
+    ) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            residence_id=residence_id,
+            device_id=device_id,
+            button_id=button_id,
+        )
+        self._config_entry_id = config_entry_id
+
+    @property
+    def name(self) -> str | None:
+        if self.button:
+            return f"{self.button.text} press"
+        return None
+
+    @property
+    def unique_id(self) -> str | None:
+        if self.device and self.button:
+            return f"{self.device.mac}-{self.button.id}-event"
+        return None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        signal = f"{SIGNAL_NOTIFICATION}_{self._config_entry_id}"
+        self.async_on_remove(
+            async_dispatcher_connect(self.hass, signal, self._handle_notification)
+        )
+
+    @callback
+    def _handle_notification(self, notification: dict[str, Any]) -> None:
+        """Fire ``press`` when the cloud reports our button was pressed.
+
+        Empirical wire format on the parent IotSwitch::
+
+            {
+              "modelName": "IotSwitch", "modelId": <device_id>,
+              "data": {"btnPress": [{"button": N, "trigger": T}], ...}
+            }
+
+        Where ``button`` is the 1-indexed button number on the controller
+        (matches ``Button.number``) and ``trigger`` is the press kind
+        (``1`` is the only value seen so far; the attribute is preserved
+        verbatim so users can branch on it once more values are observed).
+        """
+        if not isinstance(notification, dict):
+            return
+        if notification.get("modelName") != "IotSwitch":
+            return
+        if notification.get("modelId") != self.device_id:
+            return
+
+        data = notification.get("data") or {}
+        presses = data.get("btnPress") if isinstance(data, dict) else None
+        if not isinstance(presses, list):
+            return
+
+        button_number = self.button.number if self.button else None
+        if button_number is None:
+            return
+
+        for press in presses:
+            if not isinstance(press, dict):
+                continue
+            if press.get("button") != button_number:
+                continue
+            self._trigger_event(
+                EVENT_TYPE_PRESS,
+                {
+                    "trigger": press.get("trigger"),
+                    "button": press.get("button"),
+                    "lastUpdated": data.get("lastUpdated"),
+                    "rssi": data.get("rssi"),
+                },
+            )
+            self.async_write_ha_state()

--- a/custom_components/leviton_decora_smart_wifi/fan.py
+++ b/custom_components/leviton_decora_smart_wifi/fan.py
@@ -1,7 +1,5 @@
 """Support for Leviton Decora Smart Wi-Fi fan entities."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any
 
@@ -14,8 +12,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import LevitonEntity
 from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN
+from .entity import LevitonEntity
 
 
 @dataclass(frozen=True)

--- a/custom_components/leviton_decora_smart_wifi/image.py
+++ b/custom_components/leviton_decora_smart_wifi/image.py
@@ -1,7 +1,5 @@
 """Support for Leviton Decora Smart Wi-Fi image entities."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
@@ -12,11 +10,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from . import LevitonEntity
+from . import LevitonDataUpdateCoordinator
 from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN
+from .entity import LevitonEntity
 
 
 @dataclass(frozen=True)
@@ -81,7 +79,7 @@ class LevitonImageEntity(LevitonEntity, ImageEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: LevitonDataUpdateCoordinator,
         residence_id: int,
         device_id: int,
         entity_description: LevitonImageEntityDescription,

--- a/custom_components/leviton_decora_smart_wifi/light.py
+++ b/custom_components/leviton_decora_smart_wifi/light.py
@@ -1,7 +1,5 @@
 """Support for Leviton Decora Smart Wi-Fi light entities."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any
 
@@ -15,8 +13,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import LevitonEntity
 from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN
+from .entity import LevitonEntity
 
 
 @dataclass(frozen=True)

--- a/custom_components/leviton_decora_smart_wifi/manifest.json
+++ b/custom_components/leviton_decora_smart_wifi/manifest.json
@@ -12,5 +12,5 @@
   "loggers": ["custom_components.leviton_decora_smart_wifi"],
   "quality_scale": "gold",
   "requirements": ["pypng==0.20220715.0", "PyQRCode==1.2.1"],
-  "version": "1.8.0"
+  "version": "2.0.0"
 }

--- a/custom_components/leviton_decora_smart_wifi/manifest.json
+++ b/custom_components/leviton_decora_smart_wifi/manifest.json
@@ -7,10 +7,10 @@
   "dependencies": [],
   "documentation": "https://github.com/schmittx/home-assistant-leviton-decora-smart-wifi",
   "integration_type": "hub",
-  "iot_class": "cloud_polling",
+  "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/schmittx/home-assistant-leviton-decora-smart-wifi/issues",
-  "loggers": [],
+  "loggers": ["custom_components.leviton_decora_smart_wifi"],
   "quality_scale": "gold",
   "requirements": ["pypng==0.20220715.0", "PyQRCode==1.2.1"],
-  "version": "1.7.2"
+  "version": "1.8.0"
 }

--- a/custom_components/leviton_decora_smart_wifi/number.py
+++ b/custom_components/leviton_decora_smart_wifi/number.py
@@ -1,7 +1,5 @@
 """Support for Leviton Decora Smart Wi-Fi number entities."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -17,9 +15,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import LevitonEntity
 from .api.const import Level
 from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN
+from .entity import LevitonEntity
 
 
 @dataclass(frozen=True)

--- a/custom_components/leviton_decora_smart_wifi/scene.py
+++ b/custom_components/leviton_decora_smart_wifi/scene.py
@@ -1,7 +1,5 @@
 """Support for Leviton Decora Smart Wi-Fi scene entities."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any
 
@@ -11,8 +9,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory, EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import LevitonEntity
 from .const import CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN
+from .entity import LevitonEntity
 
 
 @dataclass(frozen=True)

--- a/custom_components/leviton_decora_smart_wifi/select.py
+++ b/custom_components/leviton_decora_smart_wifi/select.py
@@ -1,7 +1,5 @@
 """Support for Leviton Decora Smart Wi-Fi select entities."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -12,8 +10,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import LevitonEntity
 from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN
+from .entity import LevitonEntity
 
 
 @dataclass(frozen=True)

--- a/custom_components/leviton_decora_smart_wifi/sensor.py
+++ b/custom_components/leviton_decora_smart_wifi/sensor.py
@@ -1,7 +1,5 @@
 """Support for Leviton Decora Smart Wi-Fi sensor entities."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime
@@ -20,9 +18,9 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from . import LevitonEntity
 from .api.const import GFCIStatus
 from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN
+from .entity import LevitonEntity
 
 
 @dataclass(frozen=True)

--- a/custom_components/leviton_decora_smart_wifi/strings.json
+++ b/custom_components/leviton_decora_smart_wifi/strings.json
@@ -44,8 +44,8 @@
             "advanced": {
                 "data": {
                     "save_responses": "Save server responses to custom_components/leviton_decora_smart_wifi/api/responses",
-                    "scan_interval": "Polling interval (seconds)",
-                    "timeout": "Polling timeout (seconds)"
+                    "scan_interval": "Polling interval",
+                    "timeout": "Polling timeout"
                 },
                 "description": "Server responses can be saved to a file for debugging and development support.\n\nPolling interval and timeout can be adjusted if errors are encountered.",
                 "title": "Advanced options"
@@ -71,8 +71,8 @@
             "advanced": {
                 "data": {
                     "save_responses": "Save server responses to custom_components/leviton_decora_smart_wifi/api/responses",
-                    "scan_interval": "Polling interval (seconds)",
-                    "timeout": "Polling timeout (seconds)"
+                    "scan_interval": "Polling interval",
+                    "timeout": "Polling timeout"
                 },
                 "description": "Server responses can be saved to a file for debugging and development support.\n\nPolling interval and timeout can be adjusted if errors are encountered.",
                 "title": "Advanced options"

--- a/custom_components/leviton_decora_smart_wifi/switch.py
+++ b/custom_components/leviton_decora_smart_wifi/switch.py
@@ -1,7 +1,5 @@
 """Support for Leviton Decora Smart Wi-Fi switch entities."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -16,8 +14,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import LevitonEntity
 from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN
+from .entity import LevitonEntity
 
 
 @dataclass(frozen=True)
@@ -63,6 +61,12 @@ SWITCH_DESCRIPTIONS: list[LevitonSwitchEntityDescription] = [
         is_supported=lambda device: (
             device.is_fan or device.is_light or device.is_outlet or device.is_switch
         ),
+    ),
+    LevitonSwitchEntityDescription(
+        key="smart_bulb_mode_enabled",
+        name="Smart Bulb Mode",
+        icon="mdi:lightbulb-on",
+        is_supported=lambda device: device.is_smart_bulb_mode_capable,
     ),
     LevitonSwitchEntityDescription(
         key="status_led_enabled",

--- a/custom_components/leviton_decora_smart_wifi/translations/en.json
+++ b/custom_components/leviton_decora_smart_wifi/translations/en.json
@@ -44,8 +44,8 @@
             "advanced": {
                 "data": {
                     "save_responses": "Save server responses to custom_components/leviton_decora_smart_wifi/api/responses",
-                    "scan_interval": "Polling interval (seconds)",
-                    "timeout": "Polling timeout (seconds)"
+                    "scan_interval": "Polling interval",
+                    "timeout": "Polling timeout"
                 },
                 "description": "Server responses can be saved to a file for debugging and development support.\n\nPolling interval and timeout can be adjusted if errors are encountered.",
                 "title": "Advanced options"
@@ -71,8 +71,8 @@
             "advanced": {
                 "data": {
                     "save_responses": "Save server responses to custom_components/leviton_decora_smart_wifi/api/responses",
-                    "scan_interval": "Polling interval (seconds)",
-                    "timeout": "Polling timeout (seconds)"
+                    "scan_interval": "Polling interval",
+                    "timeout": "Polling timeout"
                 },
                 "description": "Server responses can be saved to a file for debugging and development support.\n\nPolling interval and timeout can be adjusted if errors are encountered.",
                 "title": "Advanced options"

--- a/custom_components/leviton_decora_smart_wifi/update.py
+++ b/custom_components/leviton_decora_smart_wifi/update.py
@@ -1,7 +1,5 @@
 """Support for Leviton Decora Smart Wi-Fi update entities."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any
 
@@ -16,8 +14,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import LevitonEntity
-from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN, RELEASE_URL
+from .const import CONF_DEVICES, CONF_RESIDENCES, DATA_COORDINATOR, DOMAIN
+from .entity import LevitonEntity
 
 
 @dataclass(frozen=True)
@@ -102,8 +100,8 @@ class LevitonUpdateEntity(UpdateEntity, LevitonEntity):
     @property
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest version available."""
-        if self.device is not None and self.device.is_generation_two:
-            return RELEASE_URL
+        if self.firmware is not None:
+            return self.firmware.release_url
         return None
 
     @property

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,5 @@
 {
 	"name": "Leviton Decora Smart Wi-Fi",
 	"content_in_root": false,
-	"homeassistant": "2026.3.0",
-	"iot_class": "Cloud Polling",
-	"render_readme": true
+	"homeassistant": "2026.6.0"
 }


### PR DESCRIPTION
Hi! This implements the upstream "Future Plans" item: websocket support for cloud push.

## What this does
Replaces the 120s polling delay for state changes and physical button presses on scene controllers (DW4BC, D2SCS) with real-time push over the MyLeviton websocket. End-to-end latency drops to ~2 seconds.

`iot_class` is upgraded from `cloud_polling` to `cloud_push`. The polling layer remains in place as a fallback / source of truth for static device data.

## Implementation
- `api/websocket.py` — async aiohttp client to `wss://my.leviton.com/socket/websocket`. Persistent connection, native subscribe/notification protocol, 30s ping, conservative reconnect with hard floor (1-hour cooldown on auth-rejected so a flapping WS doesn't trigger Leviton's "too many failed attempts" lockout — learned this the hard way during testing).
- `event.py` — new `event` platform. One entity per scene-controller button. Fires a `press` event whenever the cloud reports a physical press, with `trigger`, `button`, `rssi`, `lastUpdated` attributes.
- `config_flow.py` — persists the full `POST /Person/login?include=user` response in a new `CONF_LOGIN_RESPONSE` entry-data field. The websocket reuses it across reconnects without re-authenticating, so we never call `api.login()` from the WS path.
- `__init__.py` — starts/stops the WS task in setup_entry/unload_entry. Subscribes only to `IotSwitch` per configured device. Notifications are also fanned out onto the HA event bus (`leviton_decora_smart_wifi_notification`) and a per-entry dispatcher signal so other code can hook in.
- `api/__init__.py` — additionally retries once with a fresh `requests.Session` on `ConnectionError` in `LevitonAPI.refresh()`. Leviton's REST endpoint silently closes pooled keep-alive connections; without this retry, every device flips to `unavailable` until the next polling cycle.
- `manifest.json` — version → 1.8.0, `iot_class` → `cloud_push`.

## Protocol
Reverse-engineered from the official myapp.leviton.com web bundle. The current handshake is:
1. Client opens WS with `Origin: https://my.leviton.com`.
2. Client sends `{token: <full login response object>}` immediately on open (matches `authenticateSocketConnection()` wired to `onOpen` in the bundle).
3. Server may emit `{type:"status", status:"not ready"}` and/or `{type:"challenge", nonce:"..."}` — these are status traffic and the client ignores them.
4. Server sends `{type:"status", status:"ready"}`.
5. Client sends `{"type":"subscribe", "subscription":{"modelName":"IotSwitch", "modelId":N}}` per device.
6. Server pushes `{"type":"notification", "notification":{"modelName":"IotSwitch", "modelId":N, "data":{...}, "event":"saved"}}` for every change.

Physical button presses arrive on the **parent IotSwitch** as `data.btnPress: [{"button": N, "trigger": T}]`. There is no separate `IotButton` push channel.

This is informed by [tbaur/homebridge-myleviton](https://github.com/tbaur/homebridge-myleviton) (Apache-2.0, Apple HomeKit bridge) and [rwoldberg/ldata-ha](https://github.com/rwoldberg/ldata-ha) (uses the same auth pattern at `wss://socket.cloud.leviton.com/`). Credit to both.

## Tested on
- DW4BC scene controller paired with a Carnation hub, configured devices: DW4BC + a DW6HD dimmer
- HA 2026.4.x on Python 3.14
- All 4 buttons confirmed firing the event entity end-to-end with ~2s latency

## Caveats
- Leviton's cloud only emits `btnPress` for buttons that have at least one action configured in the MyLeviton mobile app. Buttons with no action are silent — there is no separate raw-press channel and no fix integration-side. README documents this.
- The `trigger` field has only been observed as `1` (single press) so far. Long-press/double-tap likely use other values; the event entity exposes `trigger` as an attribute so users can filter on it once we observe more.
- I did not introduce changes to the existing polling path beyond the connection-retry resilience fix. All existing entity types continue to work as before.

## Reference
Closes the websocket item in #3 (open since 2023). Happy to iterate on review feedback — naming, tests, anything else.